### PR TITLE
chore(libraries): tighten lints and enable release LTO

### DIFF
--- a/libraries/Cargo.toml
+++ b/libraries/Cargo.toml
@@ -10,11 +10,26 @@ publish = false
 repository = "https://github.com/stargrid-systems/cellguard"
 rust-version = "1.93"
 
+[workspace.lints.rustdoc]
+missing_crate_level_docs = "warn"
+unescaped_backticks = "warn"
+
 # See: <https://rust-lang.github.io/rust-clippy/master/index.html>
 [workspace.lints.clippy]
+# Groups
+cargo = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+# Individual lints
+allow_attributes = "warn"
+allow_attributes_without_reason = "warn"
+expect_used = "warn"
+float_arithmetic = "warn"
+indexing_slicing = "warn"
 undocumented_unsafe_blocks = "warn"
 unnecessary_safety_comment = "warn"
 unnecessary_safety_doc = "warn"
+unwrap_used = "warn"
 
 [workspace.dependencies]
 embedded-hal = { version = "1", default-features = false }

--- a/libraries/clippy.toml
+++ b/libraries/clippy.toml
@@ -1,0 +1,2 @@
+allow-expect-in-tests = true
+allow-unwrap-in-tests = true

--- a/libraries/p3t1755/src/address.rs
+++ b/libraries/p3t1755/src/address.rs
@@ -78,6 +78,7 @@ impl Address {
     const RANGE: Range<u8> = 0x40..0x60;
 
     /// Creates an address from a u8 value if it is in the valid range.
+    #[must_use]
     pub const fn new(value: u8) -> Option<Self> {
         if value >= Self::RANGE.start && value < Self::RANGE.end {
             // SAFETY:
@@ -86,13 +87,14 @@ impl Address {
             //   `Address` variants (Addr1 through Addr32).
             // - `Self::RANGE` is 0x40..0x60, so any `value` passing the check is guaranteed
             //   to be a valid `Address` discriminant.
-            Some(unsafe { mem::transmute::<u8, Address>(value) })
+            Some(unsafe { mem::transmute::<u8, Self>(value) })
         } else {
             None
         }
     }
 
     /// Returns the u8 value of the address.
+    #[must_use]
     pub const fn get(self) -> u8 {
         self as u8
     }

--- a/libraries/p3t1755/src/alert.rs
+++ b/libraries/p3t1755/src/alert.rs
@@ -1,6 +1,6 @@
 //! Alert handling for the P3T1755 temperature sensor.
 //!
-//! The alert handling is based on the "SMBus Alert Response".
+//! The alert handling is based on the "`SMBus` Alert Response".
 
 use embedded_hal::i2c::{Error, ErrorKind, I2c, NoAcknowledgeSource};
 
@@ -33,6 +33,7 @@ impl Alert {
     }
 
     /// Returns the I2C address of the device that triggered the alert.
+    #[must_use]
     pub const fn address(self) -> Address {
         let bits = self.0 >> 1;
         // SAFETY: We only allow alerts containing valid address bits to be created.
@@ -40,6 +41,7 @@ impl Alert {
     }
 
     /// Returns the alert condition.
+    #[must_use]
     pub const fn condition(self) -> AlertCondition {
         // If the temperature is higher than THIGH, the LSB bit is 1.
         // If the temperature is lower than TLOW, the LSB bit is 0.
@@ -65,6 +67,11 @@ pub enum AlertCondition {
 /// Returns `None` if no device acknowledged the alert request (i.e. no alert is
 /// pending) or if the response doesn't correspond to a valid P3T1755 device
 /// address.
+///
+/// # Errors
+///
+/// Returns an error if the I2C read fails for a reason other than the address
+/// not being acknowledged.
 pub fn process<I: I2c>(bus: &mut I) -> Result<Option<Alert>, I::Error> {
     let mut buf = [0u8; 1];
     if let Err(err) = bus.read(0x0C, &mut buf) {

--- a/libraries/p3t1755/src/lib.rs
+++ b/libraries/p3t1755/src/lib.rs
@@ -1,6 +1,7 @@
 //! NXP P3T1755 temperature sensor driver.
 
 #![no_std]
+#![warn(missing_docs)]
 
 use embedded_hal::i2c::{I2c, Operation};
 
@@ -37,6 +38,10 @@ impl<I: I2c> P3t1755<I> {
     }
 
     /// Reads the configuration register.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn read_config(&mut self) -> Result<Config, I::Error> {
         let mut buf = [0u8; 1];
         self.read_register(Register::Conf, &mut buf)?;
@@ -44,39 +49,63 @@ impl<I: I2c> P3t1755<I> {
     }
 
     /// Writes the configuration register.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn write_config(&mut self, config: Config) -> Result<(), I::Error> {
         self.write_register(Register::Conf, &[config.to_reg()])
     }
 
     /// Reads the `TLOW` register.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn read_t_low(&mut self) -> Result<Temperature, I::Error> {
         let mut buf = [0u8; 2];
         self.read_register(Register::TLow, &mut buf)?;
-        Ok(Temperature::from_regs(&buf))
+        Ok(Temperature::from_regs(buf))
     }
 
     /// Writes the `TLOW` register.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn write_t_low(&mut self, temp: Temperature) -> Result<(), I::Error> {
         self.write_register(Register::TLow, &temp.to_regs())
     }
 
     /// Reads the `THIGH` register.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn read_t_high(&mut self) -> Result<Temperature, I::Error> {
         let mut buf = [0u8; 2];
         self.read_register(Register::THigh, &mut buf)?;
-        Ok(Temperature::from_regs(&buf))
+        Ok(Temperature::from_regs(buf))
     }
 
     /// Writes the `THIGH` register.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn write_t_high(&mut self, temp: Temperature) -> Result<(), I::Error> {
         self.write_register(Register::THigh, &temp.to_regs())
     }
 
     /// Reads the temperature register.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn read_temperature(&mut self) -> Result<Temperature, I::Error> {
         let mut buf = [0u8; 2];
         self.read_register(Register::Temp, &mut buf)?;
-        Ok(Temperature::from_regs(&buf))
+        Ok(Temperature::from_regs(buf))
     }
 
     fn read_register(&mut self, reg: Register, buf: &mut [u8]) -> Result<(), I::Error> {

--- a/libraries/p3t1755/src/register.rs
+++ b/libraries/p3t1755/src/register.rs
@@ -34,7 +34,9 @@ impl Register {
     }
 }
 
+/// Contents of the configuration register.
 #[derive(Clone, Copy)]
+#[must_use]
 pub struct Config(u8);
 
 impl Config {
@@ -51,12 +53,10 @@ impl Config {
         self.0
     }
 
-    #[inline]
     const fn bit(self, bit: u8) -> bool {
         self.0 & bit != 0
     }
 
-    #[inline]
     const fn with_bit(mut self, bit: u8, enable: bool) -> Self {
         if enable {
             self.0 |= bit;
@@ -78,6 +78,7 @@ impl Config {
     const OS_BIT: u8 = 0b1000_0000;
 
     /// Returns true if shutdown mode is enabled.
+    #[must_use]
     pub const fn shutdown_mode(self) -> bool {
         self.bit(Self::SD_BIT)
     }
@@ -88,6 +89,7 @@ impl Config {
     }
 
     /// Returns true if thermostat mode is enabled.
+    #[must_use]
     pub const fn thermostat_mode(self) -> bool {
         self.bit(Self::TM_BIT)
     }
@@ -98,6 +100,7 @@ impl Config {
     }
 
     /// Returns true if the polarity is active high.
+    #[must_use]
     pub const fn polarity(self) -> bool {
         self.bit(Self::POL_BIT)
     }
@@ -108,6 +111,7 @@ impl Config {
     }
 
     /// Returns the fault queue setting.
+    #[must_use]
     pub const fn fault_queue(self) -> FaultQueue {
         FaultQueue::from_reg(self.0)
     }
@@ -120,6 +124,7 @@ impl Config {
     }
 
     /// Returns the conversion time setting.
+    #[must_use]
     pub const fn conversion_time(self) -> ConversionTime {
         ConversionTime::from_reg(self.0)
     }
@@ -132,6 +137,7 @@ impl Config {
     }
 
     /// Returns true if one-shot mode is enabled.
+    #[must_use]
     pub const fn one_shot(self) -> bool {
         self.bit(Self::OS_BIT)
     }
@@ -142,13 +148,18 @@ impl Config {
     }
 }
 
+/// Number of consecutive faults required before the alert is asserted.
 #[derive(Clone, Copy, Default)]
 #[repr(u8)]
 pub enum FaultQueue {
+    /// One fault.
     One = 0b00_000,
+    /// Two faults.
     #[default]
     Two = 0b01_000,
+    /// Four faults.
     Four = 0b10_000,
+    /// Six faults.
     Six = 0b11_000,
 }
 
@@ -166,6 +177,7 @@ impl FaultQueue {
     }
 }
 
+/// Temperature conversion time.
 #[derive(Clone, Copy, Default)]
 #[repr(u8)]
 pub enum ConversionTime {
@@ -199,6 +211,7 @@ impl ConversionTime {
 /// The value is internally stored in 1/16°C. The valid range is -2048 to 2047
 /// representing -128.0°C to +127.9375°C.
 #[derive(Clone, Copy)]
+#[must_use]
 pub struct Temperature(i16);
 
 impl Temperature {
@@ -207,9 +220,9 @@ impl Temperature {
     /// Maximum temperature (+127.9375 °C).
     pub const MAX: Self = Self(2047);
 
-    pub(crate) const fn from_regs(regs: &[u8; 2]) -> Self {
+    pub(crate) const fn from_regs(regs: [u8; 2]) -> Self {
         // MSByte first (big-endian)
-        let raw = i16::from_be_bytes(*regs);
+        let raw = i16::from_be_bytes(regs);
         // Only the 12 MSBs are valid temperature data.
         Self(raw >> 4)
     }
@@ -222,6 +235,7 @@ impl Temperature {
     /// Creates a temperature from a raw value in 1/16 °C units.
     ///
     /// Returns `None` if the value is out of range.
+    #[must_use]
     pub const fn from_raw(raw: i16) -> Option<Self> {
         if raw < Self::MIN.0 || raw > Self::MAX.0 {
             None
@@ -253,6 +267,10 @@ impl Temperature {
     /// The resulting value is an approximation since the sensor has a
     /// resolution of 0.0625 °C. If the value is out of range, it saturates
     /// to the min/max valid range.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "raw is bounded by the i16 input to +/-5243, which fits in i16"
+    )]
     pub const fn from_centi_degrees_celsius(centi_deg_c: i16) -> Self {
         // We need i32 to avoid overflow when multiplying by 16.
         let raw = (centi_deg_c as i32 * 16) / 100;
@@ -260,11 +278,17 @@ impl Temperature {
     }
 
     /// Returns the raw temperature value in 1/16 °C.
+    #[must_use]
     pub const fn raw(self) -> i16 {
         self.0
     }
 
     /// Returns the temperature truncated to degrees Celsius (°C).
+    #[must_use]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the 12-bit value shifted right by 4 fits in i8"
+    )]
     pub const fn degrees_celsius(self) -> i8 {
         // The value only has 12 bits, so shifting right by 4 leaves us with exactly 8
         // bits.
@@ -272,6 +296,11 @@ impl Temperature {
     }
 
     /// Returns the temperature in centi-degrees Celsius (1/100 °C).
+    #[must_use]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the 12-bit input bounds the result to +/-12800, which fits in i16"
+    )]
     pub const fn centi_degrees_celsius(self) -> i16 {
         // We need i32 to avoid overflow when multiplying by 625.
         let centi_deg_c = (self.0 as i32 * 625) / 100;
@@ -375,7 +404,7 @@ mod tests {
         let t = Temperature::from_raw(401).unwrap();
         let regs = t.to_regs();
         assert_eq!(regs, [0x19, 0x10]);
-        let t2 = Temperature::from_regs(&regs);
+        let t2 = Temperature::from_regs(regs);
         assert_eq!(t2.raw(), 401);
         assert_eq!(t2.degrees_celsius(), 25);
         assert_eq!(t2.centi_degrees_celsius(), 2506);
@@ -386,7 +415,7 @@ mod tests {
         let t = Temperature::from_raw(-168).unwrap();
         let regs = t.to_regs();
         assert_eq!(regs, [0xF5, 0x80]);
-        let t2 = Temperature::from_regs(&regs);
+        let t2 = Temperature::from_regs(regs);
         assert_eq!(t2.raw(), -168);
         assert_eq!(t2.degrees_celsius(), -11);
         assert_eq!(t2.centi_degrees_celsius(), -1050);

--- a/libraries/p3t1755/tests/integration_test.rs
+++ b/libraries/p3t1755/tests/integration_test.rs
@@ -34,7 +34,7 @@ enum MockOperation {
 struct MockError(ErrorKind);
 
 impl MockError {
-    fn new(kind: ErrorKind) -> Self {
+    const fn new(kind: ErrorKind) -> Self {
         Self(kind)
     }
 }
@@ -51,58 +51,51 @@ impl ErrorType for MockI2c {
 
 impl I2c for MockI2c {
     fn read(&mut self, addr: u8, buf: &mut [u8]) -> Result<(), Self::Error> {
-        if self.current >= self.expectations.len() {
-            panic!("Unexpected I2C read to address 0x{:02X}", addr);
-        }
-
-        let expected = &self.expectations[self.current];
+        let Some(expected) = self.expectations.get(self.current) else {
+            panic!("Unexpected I2C read to address 0x{addr:02X}");
+        };
         self.current += 1;
 
-        if addr != expected.addr {
-            panic!(
-                "I2C address mismatch: expected 0x{:02X}, got 0x{:02X}",
-                expected.addr, addr
-            );
-        }
+        assert!(
+            addr == expected.addr,
+            "I2C address mismatch: expected 0x{:02X}, got 0x{:02X}",
+            expected.addr,
+            addr
+        );
 
-        if expected.operations.len() != 1 {
+        let [operation] = expected.operations.as_slice() else {
             panic!(
                 "Operation count mismatch for read: expected 1, got {}",
                 expected.operations.len()
             );
-        }
+        };
 
-        match expected.operations[0].clone() {
+        match operation.clone() {
             MockOperation::Read(expected_data) => {
-                if buf.len() != expected_data.len() {
-                    panic!(
-                        "Read buffer size mismatch: expected {}, got {}",
-                        expected_data.len(),
-                        buf.len()
-                    );
-                }
+                assert!(
+                    buf.len() == expected_data.len(),
+                    "Read buffer size mismatch: expected {}, got {}",
+                    expected_data.len(),
+                    buf.len()
+                );
                 buf.copy_from_slice(&expected_data);
                 Ok(())
             }
             MockOperation::ReadNackAddress => Err(MockError::new(ErrorKind::NoAcknowledge(
                 NoAcknowledgeSource::Address,
             ))),
-            other => panic!("Unexpected operation for read: {:?}", other),
+            other @ MockOperation::Write(_) => {
+                panic!("Unexpected operation for read: {other:?}")
+            }
         }
     }
 
     fn write(&mut self, addr: u8, _bytes: &[u8]) -> Result<(), Self::Error> {
-        panic!(
-            "Unexpected write without expectations to addr 0x{:02X}",
-            addr
-        );
+        panic!("Unexpected write without expectations to addr 0x{addr:02X}");
     }
 
     fn write_read(&mut self, addr: u8, _bytes: &[u8], _buf: &mut [u8]) -> Result<(), Self::Error> {
-        panic!(
-            "Unexpected write_read without expectations to addr 0x{:02X}",
-            addr
-        );
+        panic!("Unexpected write_read without expectations to addr 0x{addr:02X}");
     }
 
     fn transaction(
@@ -110,27 +103,24 @@ impl I2c for MockI2c {
         addr: u8,
         operations: &mut [Operation<'_>],
     ) -> Result<(), Self::Error> {
-        if self.current >= self.expectations.len() {
-            panic!("Unexpected I2C transaction to address 0x{:02X}", addr);
-        }
-
-        let expected = &self.expectations[self.current];
+        let Some(expected) = self.expectations.get(self.current) else {
+            panic!("Unexpected I2C transaction to address 0x{addr:02X}");
+        };
         self.current += 1;
 
-        if addr != expected.addr {
-            panic!(
-                "I2C address mismatch: expected 0x{:02X}, got 0x{:02X}",
-                expected.addr, addr
-            );
-        }
+        assert!(
+            addr == expected.addr,
+            "I2C address mismatch: expected 0x{:02X}, got 0x{:02X}",
+            expected.addr,
+            addr
+        );
 
-        if operations.len() != expected.operations.len() {
-            panic!(
-                "Operation count mismatch: expected {}, got {}",
-                expected.operations.len(),
-                operations.len()
-            );
-        }
+        assert!(
+            operations.len() == expected.operations.len(),
+            "Operation count mismatch: expected {}, got {}",
+            expected.operations.len(),
+            operations.len()
+        );
 
         for (i, (op, expected_op)) in operations
             .iter_mut()
@@ -139,22 +129,20 @@ impl I2c for MockI2c {
         {
             match (op, expected_op) {
                 (Operation::Write(data), MockOperation::Write(expected_data)) => {
-                    if *data != expected_data.as_slice() {
-                        panic!(
-                            "Write data mismatch at operation {}: expected {:?}, got {:?}",
-                            i, expected_data, data
-                        );
-                    }
+                    assert!(
+                        *data == expected_data.as_slice(),
+                        "Write data mismatch at operation {i}: expected {expected_data:?}, got \
+                         {data:?}"
+                    );
                 }
                 (Operation::Read(buf), MockOperation::Read(expected_data)) => {
-                    if buf.len() != expected_data.len() {
-                        panic!(
-                            "Read buffer size mismatch at operation {}: expected {}, got {}",
-                            i,
-                            expected_data.len(),
-                            buf.len()
-                        );
-                    }
+                    assert!(
+                        buf.len() == expected_data.len(),
+                        "Read buffer size mismatch at operation {}: expected {}, got {}",
+                        i,
+                        expected_data.len(),
+                        buf.len()
+                    );
                     buf.copy_from_slice(expected_data);
                 }
                 (_, MockOperation::ReadNackAddress) => {
@@ -162,7 +150,7 @@ impl I2c for MockI2c {
                         NoAcknowledgeSource::Address,
                     )));
                 }
-                _ => panic!("Operation type mismatch at operation {}", i),
+                _ => panic!("Operation type mismatch at operation {i}"),
             }
         }
 
@@ -171,7 +159,7 @@ impl I2c for MockI2c {
 }
 
 impl MockI2c {
-    fn new(expectations: Vec<Transaction>) -> Self {
+    const fn new(expectations: Vec<Transaction>) -> Self {
         Self {
             expectations,
             current: 0,
@@ -179,13 +167,12 @@ impl MockI2c {
     }
 
     fn done(&self) {
-        if self.current != self.expectations.len() {
-            panic!(
-                "Not all expected transactions were executed: {}/{}",
-                self.current,
-                self.expectations.len()
-            );
-        }
+        assert!(
+            self.current == self.expectations.len(),
+            "Not all expected transactions were executed: {}/{}",
+            self.current,
+            self.expectations.len()
+        );
     }
 }
 
@@ -395,7 +382,7 @@ fn test_different_addresses() {
         (Address::Addr32, 0x5F),
     ];
 
-    for (addr_enum, addr_val) in addresses.iter() {
+    for (addr_enum, addr_val) in &addresses {
         let mock = MockI2c::new(vec![Transaction {
             addr: *addr_val,
             operations: vec![

--- a/libraries/tca9535/src/lib.rs
+++ b/libraries/tca9535/src/lib.rs
@@ -5,6 +5,8 @@
 //! as types implementing the `embedded-hal` traits are not zero-cost.
 
 #![no_std]
+// Set per-crate so it lints the library only, not the test crates.
+#![warn(missing_docs)]
 
 use core::mem;
 use core::ops::Range;
@@ -34,38 +36,66 @@ impl<I: I2c> Tca9535<I> {
     }
 
     /// Reads the input registers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn read_input(&mut self) -> Result<Input, I::Error> {
         self.read_register_pair(INPUT_PORT0).map(Input)
     }
 
     /// Reads the output registers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn read_output(&mut self) -> Result<Output, I::Error> {
         self.read_register_pair(OUTPUT_PORT0).map(Output)
     }
 
     /// Writes the output registers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn write_output(&mut self, value: Output) -> Result<(), I::Error> {
         self.write_register_pair(OUTPUT_PORT0, value.0)
     }
 
     /// Reads the polarity inversion registers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn read_polarity_inversion(&mut self) -> Result<PolarityInversion, I::Error> {
         self.read_register_pair(POLARITY_INVERSION_PORT0)
             .map(PolarityInversion)
     }
 
     /// Writes the polarity inversion registers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn write_polarity_inversion(&mut self, value: PolarityInversion) -> Result<(), I::Error> {
         self.write_register_pair(POLARITY_INVERSION_PORT0, value.0)
     }
 
     /// Reads the configuration registers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn read_configuration(&mut self) -> Result<Configuration, I::Error> {
         self.read_register_pair(CONFIGURATION_PORT0)
             .map(Configuration)
     }
 
     /// Writes the configuration registers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I2C transaction fails.
     pub fn write_configuration(&mut self, value: Configuration) -> Result<(), I::Error> {
         self.write_register_pair(CONFIGURATION_PORT0, value.0)
     }
@@ -122,7 +152,7 @@ impl Address {
             // - `Address` is `#[repr(u8)]`.
             // - Each variant of `Address` is in the `Self::RANGE`.
             // - All values in `Self::RANGE` correspond to a variant of `Address`.
-            Some(unsafe { mem::transmute::<u8, Address>(value) })
+            Some(unsafe { mem::transmute::<u8, Self>(value) })
         } else {
             None
         }
@@ -138,27 +168,42 @@ impl Address {
 /// Bit-index for a TCA9535 pin.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PinIndex {
+    /// Pin 0 (port 0, bit 0).
     P0,
+    /// Pin 1 (port 0, bit 1).
     P1,
+    /// Pin 2 (port 0, bit 2).
     P2,
+    /// Pin 3 (port 0, bit 3).
     P3,
+    /// Pin 4 (port 0, bit 4).
     P4,
+    /// Pin 5 (port 0, bit 5).
     P5,
+    /// Pin 6 (port 0, bit 6).
     P6,
+    /// Pin 7 (port 0, bit 7).
     P7,
+    /// Pin 8 (port 1, bit 0).
     P8,
+    /// Pin 9 (port 1, bit 1).
     P9,
+    /// Pin 10 (port 1, bit 2).
     P10,
+    /// Pin 11 (port 1, bit 3).
     P11,
+    /// Pin 12 (port 1, bit 4).
     P12,
+    /// Pin 13 (port 1, bit 5).
     P13,
+    /// Pin 14 (port 1, bit 6).
     P14,
+    /// Pin 15 (port 1, bit 7).
     P15,
 }
 
 impl PinIndex {
     /// Returns the bit position of this pin (0-15).
-    #[inline]
     #[must_use]
     pub const fn bit(self) -> u8 {
         match self {
@@ -182,7 +227,6 @@ impl PinIndex {
     }
 
     /// Returns a bitmask with only this pin set.
-    #[inline]
     #[must_use]
     pub const fn mask(self) -> u16 {
         1 << self.bit()
@@ -195,14 +239,12 @@ pub struct Input(pub u16);
 
 impl Input {
     /// Returns true if the specified pin is high.
-    #[inline]
     #[must_use]
     pub const fn is_high(self, pin: PinIndex) -> bool {
         self.0 & pin.mask() != 0
     }
 
     /// Returns true if the specified pin is low.
-    #[inline]
     #[must_use]
     pub const fn is_low(self, pin: PinIndex) -> bool {
         self.0 & pin.mask() == 0
@@ -211,34 +253,29 @@ impl Input {
 
 /// Output registers.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[must_use]
 pub struct Output(pub u16);
 
 impl Output {
     /// Returns a new value with the specified pin set high.
-    #[inline]
-    #[must_use]
     pub const fn with_high(mut self, pin: PinIndex) -> Self {
         self.0 |= pin.mask();
         self
     }
 
     /// Returns a new value with the specified pin set low.
-    #[inline]
-    #[must_use]
     pub const fn with_low(mut self, pin: PinIndex) -> Self {
         self.0 &= !pin.mask();
         self
     }
 
     /// Returns true if the specified pin is high.
-    #[inline]
     #[must_use]
     pub const fn is_high(self, pin: PinIndex) -> bool {
         self.0 & pin.mask() != 0
     }
 
     /// Returns true if the specified pin is low.
-    #[inline]
     #[must_use]
     pub const fn is_low(self, pin: PinIndex) -> bool {
         self.0 & pin.mask() == 0
@@ -247,34 +284,29 @@ impl Output {
 
 /// Polarity inversion registers.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[must_use]
 pub struct PolarityInversion(pub u16);
 
 impl PolarityInversion {
     /// Returns a new value with the specified pin inverted.
-    #[inline]
-    #[must_use]
     pub const fn with_inverted(mut self, pin: PinIndex) -> Self {
         self.0 |= pin.mask();
         self
     }
 
     /// Returns a new value with the specified pin set to normal polarity.
-    #[inline]
-    #[must_use]
     pub const fn with_normal(mut self, pin: PinIndex) -> Self {
         self.0 &= !pin.mask();
         self
     }
 
     /// Returns true if the specified pin is inverted.
-    #[inline]
     #[must_use]
     pub const fn is_inverted(self, pin: PinIndex) -> bool {
         self.0 & pin.mask() != 0
     }
 
     /// Returns true if the specified pin has normal polarity.
-    #[inline]
     #[must_use]
     pub const fn is_normal(self, pin: PinIndex) -> bool {
         self.0 & pin.mask() == 0
@@ -283,34 +315,29 @@ impl PolarityInversion {
 
 /// Configuration registers.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[must_use]
 pub struct Configuration(pub u16);
 
 impl Configuration {
     /// Returns a new value with the specified pin configured as input.
-    #[inline]
-    #[must_use]
     pub const fn with_input(mut self, pin: PinIndex) -> Self {
         self.0 |= pin.mask();
         self
     }
 
     /// Returns a new value with the specified pin configured as output.
-    #[inline]
-    #[must_use]
     pub const fn with_output(mut self, pin: PinIndex) -> Self {
         self.0 &= !pin.mask();
         self
     }
 
     /// Returns true if the specified pin is configured as input.
-    #[inline]
     #[must_use]
     pub const fn is_input(self, pin: PinIndex) -> bool {
         self.0 & pin.mask() != 0
     }
 
     /// Returns true if the specified pin is configured as output.
-    #[inline]
     #[must_use]
     pub const fn is_output(self, pin: PinIndex) -> bool {
         self.0 & pin.mask() == 0


### PR DESCRIPTION
## What

Enable stricter lints for the `p3t1755` and `tca9535` driver crates and fix every finding. Also enable fat LTO for release builds.

## Lints enabled

- **clippy** (`[workspace.lints.clippy]`): `pedantic`, `nursery`, `cargo` groups (priority -1), plus the restriction lints `allow_attributes`, `allow_attributes_without_reason`, `expect_used`, `float_arithmetic`, `indexing_slicing`, `unwrap_used` (alongside the existing `undocumented_unsafe_blocks` family).
- **rustc**: `missing_docs`, set per-crate in each `lib.rs` so it lints the library API only.
- **rustdoc** (`[workspace.lints.rustdoc]`): `missing_crate_level_docs`, `unescaped_backticks` (the other useful rustdoc lints are warn-by-default).
- **clippy.toml**: `allow-unwrap-in-tests`, `allow-expect-in-tests`.

## Code changes

- `#[must_use]` at the **type** level for the value/builder newtypes (`Config`, `Temperature`, `Output`, `PolarityInversion`, `Configuration`); per-method `#[must_use]` only where the return type isn't itself must-use (bool/primitive getters).
- Documented the public API: `# Errors` sections on all `Result`-returning methods, plus enum/variant/struct docs.
- `Temperature::from_regs` now takes `[u8; 2]` by value.
- The three provably-safe temperature casts are pinned with `#[expect(clippy::cast_possible_truncation, reason = …)]`.
- Test-mock cleanups: `if/panic` → `assert!`, inlined format args, explicit match arm, `const fn`, and slice indexing replaced with `let … else { panic! }`.

## Notable decisions

- **LTO over `#[inline]`**: dropped `missing_inline_in_public_items` and removed all manual `#[inline]`, relying on `lto = true` for cross-crate inlining.
- **`missing_docs` is per-crate**, not workspace-level — workspace-level demands a `//!` on every crate, including the integration-test crates.
- **Mock uses `let-else`/`panic!`, not `.expect()`**: clippy's `allow-*-in-tests` options only cover `#[test]` fns and `#[cfg(test)]`, not the mock's trait-impl helper methods, so `.expect()`/indexing there trip `expect_used`/`indexing_slicing`.

## Verification

`cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` (55 pass), `cargo fmt --check`, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` all clean.