### PR TITLE
chore: disable Renovate automerge for Rust toolchain

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"]
+  "extends": ["config:best-practices"],
+  "packageRules": [
+    {
+      "matchFileNames": ["rust-toolchain.toml"],
+      "automerge": false,
+      "description": "Pinning the latest nightly daily is too much churn. Keep toolchain bumps as manual PRs."
+    }
+  ]
 }


### PR DESCRIPTION
Pinning the latest nightly daily and automerging it is too much churn. This keeps Rust toolchain bumps (`rust-toolchain.toml`) as manual PRs so we control the cadence.

Scoped via `matchFileNames` so it only affects the toolchain channel, not other deps.