### PR TITLE
chore: pass host USB into devcontainer for UPDI flashing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,11 @@
 {
-  "image": "ghcr.io/stargrid-systems/devcontainer-images/rust:1.0.0"
+  "image": "ghcr.io/stargrid-systems/devcontainer-images/rust:1.0.0",
+  // Pass the host USB bus through so avrdude/ravedude can reach the
+  // MPLAB PICkit Basic (04d8:9055) for UPDI flashing. The bind mount
+  // (rather than a fixed device path) survives re-plugging, since the
+  // /dev/bus/usb/<bus>/<dev> node number changes each time.
+  "privileged": true,
+  "mounts": [
+    { "source": "/dev/bus/usb", "target": "/dev/bus/usb", "type": "bind" }
+  ]
 }


### PR DESCRIPTION
Passes the host USB bus into the devcontainer so avrdude/ravedude can reach the MPLAB PICkit Basic for UPDI flashing.

Uses the dedicated \`privileged\` and \`mounts\` options from the [dev container spec](https://containers.dev/implementors/json_reference/) instead of \`runArgs\`, which is not needed here.