### PR TITLE
feat: add NVMCTRL driver for AVR128 EEPROM and USERROW

### DIFF
--- a/avrxt-hal/src/clock.rs
+++ b/avrxt-hal/src/clock.rs
@@ -23,6 +23,11 @@ pub trait CcpUnlock {
     /// Writes the IOREG signature to `CPU.CCP`, opening the ~4-cycle window in
     /// which the next protected store is accepted.
     fn unlock_ioreg(&self);
+
+    /// Writes the SPM signature to `CPU.CCP`, opening the window for the next
+    /// protected store. `NVMCTRL.CTRLA` is protected with this signature, not
+    /// the IOREG one.
+    fn unlock_spm(&self);
 }
 
 // Shared body, invoked from the family submodule that owns each device. Exposed
@@ -33,6 +38,10 @@ macro_rules! impl_ccp_unlock {
             #[inline(always)]
             fn unlock_ioreg(&self) {
                 self.ccp().write(|w| w.ccp().ioreg());
+            }
+            #[inline(always)]
+            fn unlock_spm(&self) {
+                self.ccp().write(|w| w.ccp().spm());
             }
         }
     };

--- a/avrxt-hal/src/lib.rs
+++ b/avrxt-hal/src/lib.rs
@@ -25,13 +25,24 @@
 //!
 //! # Peripherals
 //!
-//! clock ([`clock`]), delay ([`delay`]), GPIO ([`gpio`]), I2C/TWI ([`twi`]),
-//! SPI ([`spi`]), USART ([`usart`]), timer PWM ([`pwm`]), ADC ([`adc`]), DAC
-//! ([`dac`]), voltage reference ([`vref`]), watchdog ([`wdt`]), RTC ([`rtc`]),
-//! custom logic ([`ccl`]), op-amps ([`opamp`]), zero-cross ([`zcd`]) and the
-//! signature row ([`sigrow`]). AVR128 also exposes the non-volatile memory
-//! controller ([`nvmctrl`]) for on-chip EEPROM and USERROW. tinyAVR covers the
-//! subset that maps to its peripherals: clock, delay, gpio, usart, adc and wdt.
+//! - clock ([`clock`])
+//! - delay ([`delay`])
+//! - GPIO ([`gpio`])
+//! - I2C/TWI ([`twi`])
+//! - SPI ([`spi`])
+//! - USART ([`usart`])
+//! - timer PWM ([`pwm`])
+//! - ADC ([`adc`])
+//! - DAC ([`dac`])
+//! - voltage reference ([`vref`])
+//! - watchdog ([`wdt`])
+//! - RTC ([`rtc`])
+//! - custom logic ([`ccl`])
+//! - op-amps ([`opamp`])
+//! - zero-cross ([`zcd`])
+//! - signature row ([`sigrow`])
+//! - non-volatile memory controller ([`nvmctrl`], AVR128 only) for on-chip
+//!   EEPROM and USERROW
 
 #![no_std]
 #![allow(

--- a/avrxt-hal/src/lib.rs
+++ b/avrxt-hal/src/lib.rs
@@ -29,8 +29,9 @@
 //! SPI ([`spi`]), USART ([`usart`]), timer PWM ([`pwm`]), ADC ([`adc`]), DAC
 //! ([`dac`]), voltage reference ([`vref`]), watchdog ([`wdt`]), RTC ([`rtc`]),
 //! custom logic ([`ccl`]), op-amps ([`opamp`]), zero-cross ([`zcd`]) and the
-//! signature row ([`sigrow`]). tinyAVR covers the subset that maps to its
-//! peripherals: clock, delay, gpio, usart, adc and wdt.
+//! signature row ([`sigrow`]). AVR128 also exposes the non-volatile memory
+//! controller ([`nvmctrl`]) for on-chip EEPROM and USERROW. tinyAVR covers the
+//! subset that maps to its peripherals: clock, delay, gpio, usart, adc and wdt.
 
 #![no_std]
 #![allow(
@@ -47,6 +48,8 @@ pub mod clock;
 pub mod dac;
 pub mod delay;
 pub mod gpio;
+#[cfg(feature = "_avr128")]
+pub mod nvmctrl;
 pub mod opamp;
 pub mod pwm;
 pub mod rtc;

--- a/avrxt-hal/src/lib.rs
+++ b/avrxt-hal/src/lib.rs
@@ -41,9 +41,10 @@
 //! - op-amps ([`opamp`])
 //! - zero-cross ([`zcd`])
 //! - signature row ([`sigrow`])
-//! - non-volatile memory controller ([`nvmctrl`], AVR128 only) for on-chip
-//!   EEPROM and USERROW
-
+#![cfg_attr(
+    feature = "_avr128",
+    doc = "- non-volatile memory controller ([`nvmctrl`]) for on-chip EEPROM and USERROW"
+)]
 #![no_std]
 #![allow(
     unused_macros,

--- a/avrxt-hal/src/nvmctrl.rs
+++ b/avrxt-hal/src/nvmctrl.rs
@@ -1,14 +1,14 @@
 //! Non-volatile memory controller (NVMCTRL) for AVR128 DA/DB.
 //!
 //! [`Nvm`] programs the on-chip EEPROM and the USERROW. It is generic over an
-//! [`NvmInstance`] (implemented for each AVR128 `NVMCTRL`). Program flash is not
-//! written here: on `CellGuard` a separate programmer drives the target over
-//! UPDI, so a running application never rewrites its own code.
+//! [`NvmInstance`] (implemented for each AVR128 `NVMCTRL`). Program flash is
+//! not written here: on `CellGuard` a separate programmer drives the target
+//! over UPDI, so a running application never rewrites its own code.
 //!
 //! `NVMCTRL.CTRLA` is configuration-change protected with the SPM signature, so
 //! every command goes through [`CcpUnlock::unlock_spm`] inside
-//! `avr_device::interrupt::free`: an interrupt cannot land in the unlock window.
-//! Do not run an NVM operation from an interrupt handler.
+//! `avr_device::interrupt::free`: an interrupt cannot land in the unlock
+//! window. Do not run an NVM operation from an interrupt handler.
 //!
 //! The register command sequences here follow the AVR Dx model and match the
 //! DxCore reference flows. They cannot be exercised without hardware, so treat
@@ -34,39 +34,18 @@ const fn check_bounds(offset: u16, len: usize, size: u16) -> Result<(), NvmError
     }
 }
 
-/// Reads one byte from a memory-mapped NVM address.
-#[inline]
-fn read_byte(addr: u16) -> u8 {
-    // SAFETY: `addr` is a data-space address of memory-mapped NVM, bounds
-    // checked by the caller against the region size. A volatile byte read of
-    // mapped NVM has no side effects.
-    unsafe { core::ptr::read_volatile(addr as *const u8) }
-}
-
-/// Writes one byte to a memory-mapped NVM address.
-///
-/// The store loads the NVM page buffer (EEPROM) or is committed by the armed
-/// flash command (USERROW). The caller issues the matching NVM command.
-#[inline]
-fn write_byte(addr: u16, val: u8) {
-    // SAFETY: `addr` is a data-space address of memory-mapped NVM, bounds
-    // checked by the caller against the region size. The store only affects the
-    // NVM page buffer or the armed flash write, which the caller then commits.
-    unsafe { core::ptr::write_volatile(addr as *mut u8, val) }
-}
-
-/// An `NVMCTRL` peripheral. Implemented for each AVR128 device. Not for external
-/// use.
+/// An `NVMCTRL` peripheral. Implemented for each AVR128 device. Not for
+/// external use.
 ///
 /// The associated constants give each region's data-space base and size, so a
 /// future part with a different map only changes these values.
 pub trait NvmInstance {
-    /// Data-space base address of the on-chip EEPROM.
-    const EEPROM_START: u16;
+    /// Data-space base pointer of the on-chip EEPROM.
+    const EEPROM_START: *mut u8;
     /// On-chip EEPROM size in bytes.
     const EEPROM_SIZE: u16;
-    /// Data-space base address of the USERROW.
-    const USERROW_START: u16;
+    /// Data-space base pointer of the USERROW.
+    const USERROW_START: *mut u8;
     /// USERROW size in bytes.
     const USERROW_SIZE: u16;
 
@@ -121,10 +100,12 @@ impl<T: NvmInstance> Nvm<T> {
     /// [`NvmError::OutOfBounds`] if the range leaves the EEPROM.
     pub fn read_eeprom(&self, offset: u16, buf: &mut [u8]) -> Result<(), NvmError> {
         check_bounds(offset, buf.len(), T::EEPROM_SIZE)?;
-        let mut addr = T::EEPROM_START + offset;
+        let mut addr = T::EEPROM_START.wrapping_add(offset as usize);
         for slot in buf {
-            *slot = read_byte(addr);
-            addr += 1;
+            // SAFETY: `check_bounds` kept `offset + buf.len()` inside the EEPROM,
+            // so every `addr` stays within the mapped region.
+            *slot = unsafe { addr.read_volatile() };
+            addr = addr.wrapping_add(1);
         }
         Ok(())
     }
@@ -146,12 +127,15 @@ impl<T: NvmInstance> Nvm<T> {
         cpu: &C,
     ) -> Result<(), NvmError> {
         check_bounds(offset, data.len(), T::EEPROM_SIZE)?;
-        let mut addr = T::EEPROM_START + offset;
+        let mut addr = T::EEPROM_START.wrapping_add(offset as usize);
         for &b in data {
             self.instance.wait_eeprom_ready();
-            write_byte(addr, b);
+            // SAFETY: `check_bounds` kept `offset + data.len()` inside the
+            // EEPROM, so every `addr` stays within the mapped region. The store
+            // loads the page buffer; the command below commits it.
+            unsafe { addr.write_volatile(b) };
             self.protected(cpu, T::command_eeprom_erase_write);
-            addr += 1;
+            addr = addr.wrapping_add(1);
         }
         self.instance.wait_eeprom_ready();
         self.protected(cpu, T::command_none);
@@ -168,10 +152,12 @@ impl<T: NvmInstance> Nvm<T> {
     /// [`NvmError::OutOfBounds`] if the range leaves the USERROW.
     pub fn read_userrow(&self, offset: u16, buf: &mut [u8]) -> Result<(), NvmError> {
         check_bounds(offset, buf.len(), T::USERROW_SIZE)?;
-        let mut addr = T::USERROW_START + offset;
+        let mut addr = T::USERROW_START.wrapping_add(offset as usize);
         for slot in buf {
-            *slot = read_byte(addr);
-            addr += 1;
+            // SAFETY: `check_bounds` kept `offset + buf.len()` inside the
+            // USERROW, so every `addr` stays within the mapped region.
+            *slot = unsafe { addr.read_volatile() };
+            addr = addr.wrapping_add(1);
         }
         Ok(())
     }
@@ -193,14 +179,17 @@ impl<T: NvmInstance> Nvm<T> {
 
         self.instance.wait_flash_ready();
         self.protected(cpu, T::command_flash_page_erase);
-        write_byte(T::USERROW_START, 0xFF);
+        // SAFETY: `USERROW_START` is the base of the mapped USERROW region.
+        unsafe { T::USERROW_START.write_volatile(0xFF) };
         self.instance.wait_flash_ready();
 
         self.protected(cpu, T::command_flash_write);
         let mut addr = T::USERROW_START;
         for &b in data {
-            write_byte(addr, b);
-            addr += 1;
+            // SAFETY: `check_bounds` kept `data.len()` inside the USERROW, so
+            // every `addr` stays within the mapped region.
+            unsafe { addr.write_volatile(b) };
+            addr = addr.wrapping_add(1);
         }
         self.instance.wait_flash_ready();
 
@@ -216,9 +205,9 @@ macro_rules! impl_nvm_instance {
     ($NVMCTRL:ty) => {
         impl NvmInstance for $NVMCTRL {
             // AVR128 DA/DB data-space map (data sheet memory overview).
-            const EEPROM_START: u16 = 0x1400;
+            const EEPROM_START: *mut u8 = 0x1400 as *mut u8;
             const EEPROM_SIZE: u16 = 512;
-            const USERROW_START: u16 = 0x1080;
+            const USERROW_START: *mut u8 = 0x1080 as *mut u8;
             const USERROW_SIZE: u16 = 32;
 
             #[inline(always)]

--- a/avrxt-hal/src/nvmctrl.rs
+++ b/avrxt-hal/src/nvmctrl.rs
@@ -11,8 +11,9 @@
 //! window. Do not run an NVM operation from an interrupt handler.
 //!
 //! The register command sequences here follow the AVR Dx model and match the
-//! DxCore reference flows. They cannot be exercised without hardware, so treat
-//! the marked sequences as bench-verify.
+//! DxCore reference flows.
+
+use core::mem::MaybeUninit;
 
 use crate::clock::CcpUnlock;
 
@@ -24,14 +25,6 @@ pub enum NvmError {
     OutOfBounds,
     /// The controller reported a write error (`STATUS.ERROR`).
     WriteFailed,
-}
-
-/// Checks that `[offset, offset + len)` fits within a region of `size` bytes.
-const fn check_bounds(offset: u16, len: usize, size: u16) -> Result<(), NvmError> {
-    match (offset as usize).checked_add(len) {
-        Some(end) if end <= size as usize => Ok(()),
-        _ => Err(NvmError::OutOfBounds),
-    }
 }
 
 /// An `NVMCTRL` peripheral. Implemented for each AVR128 device. Not for
@@ -99,22 +92,30 @@ impl<T: NvmInstance> Nvm<T> {
     ///
     /// [`NvmError::OutOfBounds`] if the range leaves the EEPROM.
     pub fn read_eeprom(&self, offset: u16, buf: &mut [u8]) -> Result<(), NvmError> {
-        check_bounds(offset, buf.len(), T::EEPROM_SIZE)?;
-        let mut addr = T::EEPROM_START.wrapping_add(offset as usize);
-        for slot in buf {
-            // SAFETY: `check_bounds` kept `offset + buf.len()` inside the EEPROM,
-            // so every `addr` stays within the mapped region.
-            *slot = unsafe { addr.read_volatile() };
-            addr = addr.wrapping_add(1);
-        }
+        self.read_eeprom_uninit(offset, as_uninit(buf))?;
         Ok(())
+    }
+
+    /// Reads `buf.len()` bytes from the on-chip EEPROM at `offset` into an
+    /// uninitialized buffer, returning the bytes that were read.
+    ///
+    /// # Errors
+    ///
+    /// [`NvmError::OutOfBounds`] if the range leaves the EEPROM.
+    pub fn read_eeprom_uninit<'a>(
+        &self,
+        offset: u16,
+        buf: &'a mut [MaybeUninit<u8>],
+    ) -> Result<&'a mut [u8], NvmError> {
+        // SAFETY: `EEPROM_START` bases the mapped EEPROM of `EEPROM_SIZE` bytes.
+        unsafe { read_region(offset, buf, T::EEPROM_START, T::EEPROM_SIZE) }
     }
 
     /// Writes `data` to the on-chip EEPROM at `offset`.
     ///
     /// Uses the erase-write command per byte, so callers do not pre-erase. This
     /// follows the DxCore EEPROM flow: store the byte to load the page buffer,
-    /// then issue `EEERWR` to commit it. Bench-verify.
+    /// then issue `EEERWR` to commit it.
     ///
     /// # Errors
     ///
@@ -151,15 +152,24 @@ impl<T: NvmInstance> Nvm<T> {
     ///
     /// [`NvmError::OutOfBounds`] if the range leaves the USERROW.
     pub fn read_userrow(&self, offset: u16, buf: &mut [u8]) -> Result<(), NvmError> {
-        check_bounds(offset, buf.len(), T::USERROW_SIZE)?;
-        let mut addr = T::USERROW_START.wrapping_add(offset as usize);
-        for slot in buf {
-            // SAFETY: `check_bounds` kept `offset + buf.len()` inside the
-            // USERROW, so every `addr` stays within the mapped region.
-            *slot = unsafe { addr.read_volatile() };
-            addr = addr.wrapping_add(1);
-        }
+        self.read_userrow_uninit(offset, as_uninit(buf))?;
         Ok(())
+    }
+
+    /// Reads `buf.len()` bytes from the USERROW at `offset` into an
+    /// uninitialized buffer, returning the bytes that were read.
+    ///
+    /// # Errors
+    ///
+    /// [`NvmError::OutOfBounds`] if the range leaves the USERROW.
+    pub fn read_userrow_uninit<'a>(
+        &self,
+        offset: u16,
+        buf: &'a mut [MaybeUninit<u8>],
+    ) -> Result<&'a mut [u8], NvmError> {
+        // SAFETY: `USERROW_START` bases the mapped USERROW of `USERROW_SIZE`
+        // bytes.
+        unsafe { read_region(offset, buf, T::USERROW_START, T::USERROW_SIZE) }
     }
 
     /// Erases the USERROW and writes `data` from its start.
@@ -168,7 +178,6 @@ impl<T: NvmInstance> Nvm<T> {
     /// whole page then writes `data`. Bytes past `data` are left erased
     /// (`0xFF`). Follows the AVR Dx flash flow (command-first): arm `FLPER`,
     /// trigger the erase with a store, then arm `FLWR` and store the bytes.
-    /// Bench-verify.
     ///
     /// # Errors
     ///
@@ -201,6 +210,55 @@ impl<T: NvmInstance> Nvm<T> {
     }
 }
 
+/// Checks that `[offset, offset + len)` fits within a region of `size` bytes.
+const fn check_bounds(offset: u16, len: usize, size: u16) -> Result<(), NvmError> {
+    match (offset as usize).checked_add(len) {
+        Some(end) if end <= size as usize => Ok(()),
+        _ => Err(NvmError::OutOfBounds),
+    }
+}
+
+/// Views an initialized byte slice as uninitialized, so an initialized read can
+/// reuse the uninitialized read path. Sound because a `u8` is always a valid
+/// `MaybeUninit<u8>`.
+fn as_uninit(buf: &mut [u8]) -> &mut [MaybeUninit<u8>] {
+    let len = buf.len();
+    // SAFETY: `MaybeUninit<u8>` has the same layout as `u8`.
+    unsafe { core::slice::from_raw_parts_mut(buf.as_mut_ptr().cast(), len) }
+}
+
+/// Reads `buf.len()` bytes from the data-space region based at `start` into an
+/// uninitialized buffer, returning the now-initialized bytes.
+///
+/// # Safety
+///
+/// `start` must be the base of a readable data-space region of at least `size`
+/// bytes, so that `[start, start + size)` is a valid mapped range.
+///
+/// # Errors
+///
+/// [`NvmError::OutOfBounds`] if the range leaves the region.
+unsafe fn read_region(
+    offset: u16,
+    buf: &mut [MaybeUninit<u8>],
+    start: *mut u8,
+    size: u16,
+) -> Result<&mut [u8], NvmError> {
+    check_bounds(offset, buf.len(), size)?;
+    let mut addr = start.wrapping_add(offset as usize);
+    for slot in buf.iter_mut() {
+        // SAFETY: the caller guarantees `start`/`size` map a real region, and
+        // `check_bounds` kept every `addr` inside it.
+        slot.write(unsafe { addr.read_volatile() });
+        addr = addr.wrapping_add(1);
+    }
+    let len = buf.len();
+    let ptr = buf.as_mut_ptr().cast::<u8>();
+    // SAFETY: every slot in `buf` was written above, so the region is a fully
+    // initialized `[u8]` for the borrow of `buf`.
+    Ok(unsafe { core::slice::from_raw_parts_mut(ptr, len) })
+}
+
 macro_rules! impl_nvm_instance {
     ($NVMCTRL:ty) => {
         impl NvmInstance for $NVMCTRL {
@@ -212,11 +270,11 @@ macro_rules! impl_nvm_instance {
 
             #[inline(always)]
             fn wait_flash_ready(&self) {
-                while self.status().read().fbusy().bit_is_set() {}
+                crate::wait::spin_until(|| self.status().read().fbusy().bit_is_clear());
             }
             #[inline(always)]
             fn wait_eeprom_ready(&self) {
-                while self.status().read().eebusy().bit_is_set() {}
+                crate::wait::spin_until(|| self.status().read().eebusy().bit_is_clear());
             }
             #[inline(always)]
             fn write_error(&self) -> bool {

--- a/avrxt-hal/src/nvmctrl.rs
+++ b/avrxt-hal/src/nvmctrl.rs
@@ -1,0 +1,272 @@
+//! Non-volatile memory controller (NVMCTRL) for AVR128 DA/DB.
+//!
+//! [`Nvm`] programs the on-chip EEPROM and the USERROW. It is generic over an
+//! [`NvmInstance`] (implemented for each AVR128 `NVMCTRL`). Program flash is not
+//! written here: on `CellGuard` a separate programmer drives the target over
+//! UPDI, so a running application never rewrites its own code.
+//!
+//! `NVMCTRL.CTRLA` is configuration-change protected with the SPM signature, so
+//! every command goes through [`CcpUnlock::unlock_spm`] inside
+//! `avr_device::interrupt::free`: an interrupt cannot land in the unlock window.
+//! Do not run an NVM operation from an interrupt handler.
+//!
+//! The register command sequences here follow the AVR Dx model and match the
+//! DxCore reference flows. They cannot be exercised without hardware, so treat
+//! the marked sequences as bench-verify.
+
+use crate::clock::CcpUnlock;
+
+/// Something went wrong talking to non-volatile memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NvmError {
+    /// The requested range does not fit the target region.
+    OutOfBounds,
+    /// The controller reported a write error (`STATUS.ERROR`).
+    WriteFailed,
+}
+
+/// Checks that `[offset, offset + len)` fits within a region of `size` bytes.
+const fn check_bounds(offset: u16, len: usize, size: u16) -> Result<(), NvmError> {
+    match (offset as usize).checked_add(len) {
+        Some(end) if end <= size as usize => Ok(()),
+        _ => Err(NvmError::OutOfBounds),
+    }
+}
+
+/// Reads one byte from a memory-mapped NVM address.
+#[inline]
+fn read_byte(addr: u16) -> u8 {
+    // SAFETY: `addr` is a data-space address of memory-mapped NVM, bounds
+    // checked by the caller against the region size. A volatile byte read of
+    // mapped NVM has no side effects.
+    unsafe { core::ptr::read_volatile(addr as *const u8) }
+}
+
+/// Writes one byte to a memory-mapped NVM address.
+///
+/// The store loads the NVM page buffer (EEPROM) or is committed by the armed
+/// flash command (USERROW). The caller issues the matching NVM command.
+#[inline]
+fn write_byte(addr: u16, val: u8) {
+    // SAFETY: `addr` is a data-space address of memory-mapped NVM, bounds
+    // checked by the caller against the region size. The store only affects the
+    // NVM page buffer or the armed flash write, which the caller then commits.
+    unsafe { core::ptr::write_volatile(addr as *mut u8, val) }
+}
+
+/// An `NVMCTRL` peripheral. Implemented for each AVR128 device. Not for external
+/// use.
+///
+/// The associated constants give each region's data-space base and size, so a
+/// future part with a different map only changes these values.
+pub trait NvmInstance {
+    /// Data-space base address of the on-chip EEPROM.
+    const EEPROM_START: u16;
+    /// On-chip EEPROM size in bytes.
+    const EEPROM_SIZE: u16;
+    /// Data-space base address of the USERROW.
+    const USERROW_START: u16;
+    /// USERROW size in bytes.
+    const USERROW_SIZE: u16;
+
+    /// Spins until the flash/USERROW controller is idle (`!STATUS.FBUSY`).
+    fn wait_flash_ready(&self);
+    /// Spins until the EEPROM controller is idle (`!STATUS.EEBUSY`).
+    fn wait_eeprom_ready(&self);
+    /// Returns `true` if `STATUS.ERROR` flags a write error.
+    fn write_error(&self) -> bool;
+
+    /// Writes `CMD = NONE`. Caller must open the SPM window first.
+    fn command_none(&self);
+    /// Writes `CMD = EEERWR` (EEPROM erase-write). SPM window first.
+    fn command_eeprom_erase_write(&self);
+    /// Writes `CMD = FLPER` (flash page erase). SPM window first.
+    fn command_flash_page_erase(&self);
+    /// Writes `CMD = FLWR` (flash write). SPM window first.
+    fn command_flash_write(&self);
+}
+
+/// The non-volatile memory controller.
+pub struct Nvm<T: NvmInstance> {
+    instance: T,
+}
+
+impl<T: NvmInstance> Nvm<T> {
+    /// Takes ownership of the `NVMCTRL` peripheral.
+    #[must_use]
+    pub const fn new(instance: T) -> Self {
+        Self { instance }
+    }
+
+    /// Returns the wrapped peripheral.
+    #[must_use]
+    pub fn release(self) -> T {
+        self.instance
+    }
+
+    /// Runs `cmd` inside the SPM configuration-change window with interrupts
+    /// masked, so the unlock and the protected store stay adjacent.
+    fn protected<C: CcpUnlock>(&self, cpu: &C, cmd: impl FnOnce(&T)) {
+        avr_device::interrupt::free(|_| {
+            cpu.unlock_spm();
+            cmd(&self.instance);
+        });
+    }
+
+    /// Reads `buf.len()` bytes from the on-chip EEPROM at `offset`.
+    ///
+    /// # Errors
+    ///
+    /// [`NvmError::OutOfBounds`] if the range leaves the EEPROM.
+    pub fn read_eeprom(&self, offset: u16, buf: &mut [u8]) -> Result<(), NvmError> {
+        check_bounds(offset, buf.len(), T::EEPROM_SIZE)?;
+        let mut addr = T::EEPROM_START + offset;
+        for slot in buf {
+            *slot = read_byte(addr);
+            addr += 1;
+        }
+        Ok(())
+    }
+
+    /// Writes `data` to the on-chip EEPROM at `offset`.
+    ///
+    /// Uses the erase-write command per byte, so callers do not pre-erase. This
+    /// follows the DxCore EEPROM flow: store the byte to load the page buffer,
+    /// then issue `EEERWR` to commit it. Bench-verify.
+    ///
+    /// # Errors
+    ///
+    /// [`NvmError::OutOfBounds`] if the range leaves the EEPROM, or
+    /// [`NvmError::WriteFailed`] if the controller flags a write error.
+    pub fn write_eeprom<C: CcpUnlock>(
+        &self,
+        offset: u16,
+        data: &[u8],
+        cpu: &C,
+    ) -> Result<(), NvmError> {
+        check_bounds(offset, data.len(), T::EEPROM_SIZE)?;
+        let mut addr = T::EEPROM_START + offset;
+        for &b in data {
+            self.instance.wait_eeprom_ready();
+            write_byte(addr, b);
+            self.protected(cpu, T::command_eeprom_erase_write);
+            addr += 1;
+        }
+        self.instance.wait_eeprom_ready();
+        self.protected(cpu, T::command_none);
+        if self.instance.write_error() {
+            return Err(NvmError::WriteFailed);
+        }
+        Ok(())
+    }
+
+    /// Reads `buf.len()` bytes from the USERROW at `offset`.
+    ///
+    /// # Errors
+    ///
+    /// [`NvmError::OutOfBounds`] if the range leaves the USERROW.
+    pub fn read_userrow(&self, offset: u16, buf: &mut [u8]) -> Result<(), NvmError> {
+        check_bounds(offset, buf.len(), T::USERROW_SIZE)?;
+        let mut addr = T::USERROW_START + offset;
+        for slot in buf {
+            *slot = read_byte(addr);
+            addr += 1;
+        }
+        Ok(())
+    }
+
+    /// Erases the USERROW and writes `data` from its start.
+    ///
+    /// The USERROW is flash technology and a single page, so this erases the
+    /// whole page then writes `data`. Bytes past `data` are left erased
+    /// (`0xFF`). Follows the AVR Dx flash flow (command-first): arm `FLPER`,
+    /// trigger the erase with a store, then arm `FLWR` and store the bytes.
+    /// Bench-verify.
+    ///
+    /// # Errors
+    ///
+    /// [`NvmError::OutOfBounds`] if `data` is larger than the USERROW, or
+    /// [`NvmError::WriteFailed`] if the controller flags a write error.
+    pub fn write_userrow<C: CcpUnlock>(&self, data: &[u8], cpu: &C) -> Result<(), NvmError> {
+        check_bounds(0, data.len(), T::USERROW_SIZE)?;
+
+        self.instance.wait_flash_ready();
+        self.protected(cpu, T::command_flash_page_erase);
+        write_byte(T::USERROW_START, 0xFF);
+        self.instance.wait_flash_ready();
+
+        self.protected(cpu, T::command_flash_write);
+        let mut addr = T::USERROW_START;
+        for &b in data {
+            write_byte(addr, b);
+            addr += 1;
+        }
+        self.instance.wait_flash_ready();
+
+        self.protected(cpu, T::command_none);
+        if self.instance.write_error() {
+            return Err(NvmError::WriteFailed);
+        }
+        Ok(())
+    }
+}
+
+macro_rules! impl_nvm_instance {
+    ($NVMCTRL:ty) => {
+        impl NvmInstance for $NVMCTRL {
+            // AVR128 DA/DB data-space map (data sheet memory overview).
+            const EEPROM_START: u16 = 0x1400;
+            const EEPROM_SIZE: u16 = 512;
+            const USERROW_START: u16 = 0x1080;
+            const USERROW_SIZE: u16 = 32;
+
+            #[inline(always)]
+            fn wait_flash_ready(&self) {
+                while self.status().read().fbusy().bit_is_set() {}
+            }
+            #[inline(always)]
+            fn wait_eeprom_ready(&self) {
+                while self.status().read().eebusy().bit_is_set() {}
+            }
+            #[inline(always)]
+            fn write_error(&self) -> bool {
+                !self.status().read().error().is_noerror()
+            }
+            #[inline(always)]
+            fn command_none(&self) {
+                self.ctrla().write(|w| w.cmd().none());
+            }
+            #[inline(always)]
+            fn command_eeprom_erase_write(&self) {
+                self.ctrla().write(|w| w.cmd().eeerwr());
+            }
+            #[inline(always)]
+            fn command_flash_page_erase(&self) {
+                self.ctrla().write(|w| w.cmd().flper());
+            }
+            #[inline(always)]
+            fn command_flash_write(&self) {
+                self.ctrla().write(|w| w.cmd().flwr());
+            }
+        }
+    };
+}
+
+#[cfg(feature = "avr128db48")]
+impl_nvm_instance!(avr_device::avr128db48::NVMCTRL);
+#[cfg(feature = "avr128db64")]
+impl_nvm_instance!(avr_device::avr128db64::NVMCTRL);
+#[cfg(feature = "avr128da64")]
+impl_nvm_instance!(avr_device::avr128da64::NVMCTRL);
+
+// The HAL builds only for `avr-none`, so these guard `check_bounds` at compile
+// time instead of a host test runner.
+const _: () = {
+    assert!(check_bounds(0, 512, 512).is_ok());
+    assert!(check_bounds(508, 4, 512).is_ok());
+    assert!(check_bounds(512, 0, 512).is_ok());
+    assert!(check_bounds(0, 513, 512).is_err());
+    assert!(check_bounds(509, 4, 512).is_err());
+    assert!(check_bounds(u16::MAX, 2, 512).is_err());
+};


### PR DESCRIPTION
Adds an `nvmctrl` module to `avrxt-hal` for on-chip EEPROM and USERROW access on the AVR128 DA/DB family. Gated on the `_avr128` marker, since the tinyAVR uses a different NVMCTRL generation we never self-program.
