### PR TITLE
feat: add table-free crc library

### DIFF
--- a/libraries/Cargo.lock
+++ b/libraries/Cargo.lock
@@ -19,6 +19,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "0.1.0"
+
+[[package]]
 name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/libraries/Cargo.toml
+++ b/libraries/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["ads131m08", "cat25", "p3t1755", "tca9535"]
+members = ["ads131m08", "cat25", "crc", "p3t1755", "tca9535"]
 
 [workspace.package]
 authors = ["Simon Berger <simon@siku2.io>"]

--- a/libraries/crc/Cargo.toml
+++ b/libraries/crc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "crc"
+version = "0.1.0"
+description = "Small, table-free CRC-16 and CRC-32 for the CellGuard firmware."
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/libraries/crc/src/bitwise.rs
+++ b/libraries/crc/src/bitwise.rs
@@ -1,0 +1,96 @@
+//! Table-free bitwise CRC core, generic over the machine word.
+//!
+//! [`CrcCore`] holds the running state and runs the reflected bit loop once for
+//! every input byte. [`Word`] carries the only thing that differs inside that
+//! loop: the integer width and the reflected polynomial. Initial state and
+//! final xor stay in the public wrappers, since those are the only per-variant
+//! values a caller ever observes.
+
+use core::ops::{BitAnd, BitXor, Shr};
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for u16 {}
+    impl Sealed for u32 {}
+}
+
+/// A machine word the bitwise CRC core runs on.
+///
+/// Sealed: implemented only for the integer widths this crate provides.
+pub trait Word:
+    Copy
+    + self::sealed::Sealed
+    + BitAnd<Output = Self>
+    + BitXor<Output = Self>
+    + Shr<u32, Output = Self>
+{
+    /// Reflected generator polynomial.
+    const POLY: Self;
+
+    /// Widens a data byte into the low bits.
+    fn widen(byte: u8) -> Self;
+    /// Two's-complement negation, wrapping instead of panicking on overflow.
+    fn negate(self) -> Self;
+
+    /// Folds one input byte in, then runs the eight reflected bit steps.
+    #[must_use]
+    fn update_byte(self, byte: u8) -> Self {
+        let mut state = self ^ Self::widen(byte);
+        for _ in 0..8 {
+            // Branchless conditional xor: `mask` is all-ones when the low bit
+            // is set and all-zeros otherwise.
+            let mask = (state & Self::widen(1)).negate();
+            state = (state >> 1) ^ (Self::POLY & mask);
+        }
+        state
+    }
+}
+
+impl Word for u16 {
+    const POLY: Self = 0xA001;
+    fn widen(byte: u8) -> Self {
+        Self::from(byte)
+    }
+    fn negate(self) -> Self {
+        self.wrapping_neg()
+    }
+}
+
+impl Word for u32 {
+    const POLY: Self = 0xEDB8_8320;
+    fn widen(byte: u8) -> Self {
+        Self::from(byte)
+    }
+    fn negate(self) -> Self {
+        self.wrapping_neg()
+    }
+}
+
+/// Streaming state of a reflected bitwise CRC over the word `W`.
+#[derive(Debug, Clone)]
+pub struct CrcCore<W> {
+    state: W,
+}
+
+impl<W: Copy> CrcCore<W> {
+    /// Creates a core seeded with `init`.
+    #[must_use]
+    pub const fn new(init: W) -> Self {
+        Self { state: init }
+    }
+
+    /// Returns the running state, before any final xor.
+    #[must_use]
+    pub const fn state(&self) -> W {
+        self.state
+    }
+}
+
+impl<W: Word> CrcCore<W> {
+    /// Feeds `data` into the running state.
+    pub fn update(&mut self, data: &[u8]) {
+        for &byte in data {
+            self.state = self.state.update_byte(byte);
+        }
+    }
+}

--- a/libraries/crc/src/crc16.rs
+++ b/libraries/crc/src/crc16.rs
@@ -1,0 +1,65 @@
+//! CRC-16/MODBUS, polynomial `0xA001`, initial value `0xFFFF`, no final xor.
+
+use crate::bitwise::CrcCore;
+
+/// Incremental CRC-16/MODBUS calculator.
+#[derive(Debug, Clone)]
+pub struct Crc16(CrcCore<u16>);
+
+impl Default for Crc16 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Crc16 {
+    /// Creates a calculator in its initial state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(CrcCore::new(0xFFFF))
+    }
+
+    /// Feeds `data` into the calculator.
+    pub fn update(&mut self, data: &[u8]) {
+        self.0.update(data);
+    }
+
+    /// Consumes the calculator and returns the final CRC-16 value.
+    #[must_use]
+    pub const fn finalize(self) -> u16 {
+        // CRC-16/MODBUS has no final xor.
+        self.0.state()
+    }
+}
+
+/// Computes the CRC-16/MODBUS of `data` in one call.
+#[must_use]
+pub fn checksum16(data: &[u8]) -> u16 {
+    let mut crc = Crc16::new();
+    crc.update(data);
+    crc.finalize()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Crc16, checksum16};
+
+    #[test]
+    fn modbus_known_vector() {
+        assert_eq!(checksum16(b"123456789"), 0x4B37);
+    }
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(checksum16(b""), 0xFFFF);
+    }
+
+    #[test]
+    fn chunked_matches_whole() {
+        let data = b"The quick brown fox jumps over the lazy dog";
+        let mut crc = Crc16::new();
+        crc.update(data.get(..10).unwrap());
+        crc.update(data.get(10..).unwrap());
+        assert_eq!(crc.finalize(), checksum16(data));
+    }
+}

--- a/libraries/crc/src/crc32.rs
+++ b/libraries/crc/src/crc32.rs
@@ -1,0 +1,65 @@
+//! Reflected CRC-32 (IEEE 802.3), polynomial `0xEDB8_8320`.
+
+use crate::bitwise::CrcCore;
+
+/// Incremental CRC-32 (IEEE 802.3) calculator.
+#[derive(Debug, Clone)]
+pub struct Crc32(CrcCore<u32>);
+
+impl Default for Crc32 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Crc32 {
+    /// Creates a calculator in its initial state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(CrcCore::new(0xFFFF_FFFF))
+    }
+
+    /// Feeds `data` into the calculator.
+    pub fn update(&mut self, data: &[u8]) {
+        self.0.update(data);
+    }
+
+    /// Consumes the calculator and returns the final CRC-32 value.
+    #[must_use]
+    pub const fn finalize(self) -> u32 {
+        self.0.state() ^ 0xFFFF_FFFF
+    }
+}
+
+/// Computes the CRC-32 of `data` in one call.
+#[must_use]
+pub fn checksum32(data: &[u8]) -> u32 {
+    let mut crc = Crc32::new();
+    crc.update(data);
+    crc.finalize()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Crc32, checksum32};
+
+    #[test]
+    fn known_vectors() {
+        assert_eq!(checksum32(b""), 0x0000_0000);
+        assert_eq!(checksum32(b"a"), 0xE8B7_BE43);
+        assert_eq!(checksum32(b"123456789"), 0xCBF4_3926);
+        assert_eq!(
+            checksum32(b"The quick brown fox jumps over the lazy dog"),
+            0x414F_A339
+        );
+    }
+
+    #[test]
+    fn chunked_matches_whole() {
+        let data = b"The quick brown fox jumps over the lazy dog";
+        let mut crc = Crc32::new();
+        crc.update(data.get(..10).unwrap());
+        crc.update(data.get(10..).unwrap());
+        assert_eq!(crc.finalize(), checksum32(data));
+    }
+}

--- a/libraries/crc/src/lib.rs
+++ b/libraries/crc/src/lib.rs
@@ -1,0 +1,19 @@
+//! Small, table-free CRC implementations for corruption detection.
+//!
+//! Two variants are provided, each in its own module and re-exported here:
+//!
+//! - [`Crc32`]: reflected CRC-32 (IEEE 802.3), for firmware image integrity.
+//! - [`Crc16`]: CRC-16/MODBUS, for the communication frame.
+//!
+//! Both are bitwise and table-free to keep code size small on the target, and
+//! both stream: feeding data in chunks yields the same result as feeding it all
+//! at once. These detect corruption only, not tampering.
+#![no_std]
+#![warn(missing_docs)]
+
+pub use self::crc16::{Crc16, checksum16};
+pub use self::crc32::{Crc32, checksum32};
+
+mod bitwise;
+mod crc16;
+mod crc32;


### PR DESCRIPTION
Small, table-free CRC library for the CellGuard firmware:

- CRC-16/MODBUS (poly 0xA001, init 0xFFFF) for frame checks
- CRC-32/IEEE (poly 0xEDB88320) for image payloads

Both are `no_std`, allocation-free, and streaming (feed in chunks). Table-free to keep flash use low on the constrained AVR targets.