### PR TITLE
fix: stop write_eeprom on the first byte error

### DIFF
--- a/avrxt-hal/src/nvmctrl.rs
+++ b/avrxt-hal/src/nvmctrl.rs
@@ -8,7 +8,10 @@
 //! `NVMCTRL.CTRLA` is configuration-change protected with the SPM signature, so
 //! every command goes through [`CcpUnlock::unlock_spm`] inside
 //! `avr_device::interrupt::free`: an interrupt cannot land in the unlock
-//! window. Do not run an NVM operation from an interrupt handler.
+//! window. Do not run an NVM operation from an interrupt handler. This includes
+//! a plain store to the mapped EEPROM, USERROW, or flash region: such a store
+//! loads the page buffer that a foreground write is about to commit, so an
+//! interrupt that does so mid-write corrupts the buffer.
 //!
 //! The register command sequences here follow the AVR Dx model and match the
 //! DxCore reference flows.
@@ -129,20 +132,23 @@ impl<T: NvmInstance> Nvm<T> {
     ) -> Result<(), NvmError> {
         check_bounds(offset, data.len(), T::EEPROM_SIZE)?;
         let mut addr = T::EEPROM_START.wrapping_add(offset as usize);
+        self.instance.wait_eeprom_ready();
         for &b in data {
-            self.instance.wait_eeprom_ready();
             // SAFETY: `check_bounds` kept `offset + data.len()` inside the
             // EEPROM, so every `addr` stays within the mapped region. The store
             // loads the page buffer; the command below commits it.
             unsafe { addr.write_volatile(b) };
             self.protected(cpu, T::command_eeprom_erase_write);
+            self.instance.wait_eeprom_ready();
+            // Check per byte so a mid-loop failure stops here instead of
+            // writing the rest against a faulted controller.
+            if self.instance.write_error() {
+                self.protected(cpu, T::command_none);
+                return Err(NvmError::WriteFailed);
+            }
             addr = addr.wrapping_add(1);
         }
-        self.instance.wait_eeprom_ready();
         self.protected(cpu, T::command_none);
-        if self.instance.write_error() {
-            return Err(NvmError::WriteFailed);
-        }
         Ok(())
     }
 


### PR DESCRIPTION
Follow-up fix to the NVMCTRL driver merged in #32, found in code review.

- `write_eeprom` checked `STATUS.ERROR` once after the loop. It now checks after each byte and stops on the first failure, clearing the command, so a mid-loop fault no longer keeps writing against a faulted controller.
- Doc clarifies that a store to mapped NVM from an ISR counts as an NVM operation.

Reviewed against datasheet DS40002247A section 11: the driver's memory-mapped `ST` writes are byte-granular and hardware bus-waits serialize stores and reads, so the flash word-commit / FBUSY / stale-read concerns raised in review are not bugs on this path. Register sequences still want bench verification.

Note: an earlier revision also guarded `write_userrow` against empty input. That was dropped: the function is documented as erase-then-write, so an empty slice correctly clears the whole USERROW.