### PR TITLE
feat: add EXTCLK, tinyAVR SPI/RTC, and USART set_frame to avrxt-hal

### DIFF
--- a/libraries/avrxt-hal/src/clock.rs
+++ b/libraries/avrxt-hal/src/clock.rs
@@ -2,13 +2,14 @@
 //!
 //! Configuration-change-protected registers are opened with [`CcpUnlock`]. The
 //! per-family clock control lives in submodules: AVR128 selects the internal
-//! high-frequency oscillator (`set_oschf`), tinyAVR runs from `OSC20M` and
-//! adjusts the main-clock prescaler (`set_main_clock_prescaler`). Both do the
-//! CCP unlock plus the protected write inside `avr_device::interrupt::free`, so
-//! an interrupt cannot land in the unlock window.
+//! high-frequency oscillator (`set_oschf`) or an external clock (`set_extclk`),
+//! tinyAVR runs from `OSC20M` and adjusts the main-clock prescaler
+//! (`set_main_clock_prescaler`). All do the CCP unlock plus the protected write
+//! inside `avr_device::interrupt::free`, so an interrupt cannot land in the
+//! unlock window.
 
 #[cfg(feature = "_avr128")]
-pub use self::avr128::{HfFreq, OscControl, set_oschf};
+pub use self::avr128::{ExtClockControl, HfFreq, OscControl, set_extclk, set_oschf};
 #[cfg(feature = "_tinyavr")]
 pub use self::tiny::{ClkPrescaler, MainClkControl, TinyBaseFreq, set_main_clock_prescaler};
 

--- a/libraries/avrxt-hal/src/clock/avr128.rs
+++ b/libraries/avrxt-hal/src/clock/avr128.rs
@@ -1,7 +1,9 @@
-//! AVR128 high-frequency oscillator (OSCHF) clock control.
+//! AVR128 high-frequency clock control.
 //!
-//! The AVR128 DB/DA family boots on OSCHF at 4 MHz. [`set_oschf`] selects
-//! another OSCHF frequency. `OSCHFCTRLA` is configuration-change protected.
+//! The AVR128 DB/DA family boots on the internal OSCHF at 4 MHz. [`set_oschf`]
+//! selects another OSCHF frequency. [`set_extclk`] switches the main clock to
+//! an external clock instead. `OSCHFCTRLA`, `XOSCHFCTRLA` and `MCLKCTRLA` are
+//! all configuration-change protected.
 
 use super::{CcpUnlock, impl_ccp_unlock};
 
@@ -97,6 +99,103 @@ impl_osc_control!(avr_device::avr128db48::CLKCTRL);
 impl_osc_control!(avr_device::avr128db64::CLKCTRL);
 #[cfg(feature = "avr128da64")]
 impl_osc_control!(avr_device::avr128da64::CLKCTRL);
+
+/// Controls switching the main clock to an external clock source. Implemented
+/// for each device's `CLKCTRL`. Not for external use.
+///
+/// The two families reach an external clock differently. On DA parts the clock
+/// is fed straight into the EXTCLK pin, so there is no source to enable. On DB
+/// parts it comes in through the `XOSCHF` block, which must be configured as an
+/// external clock and enabled first. Both then select it with
+/// `MCLKCTRLA.CLKSEL` and report progress through `MCLKSTATUS`.
+pub trait ExtClockControl {
+    /// Enables the external clock source. On DB parts this writes `XOSCHFCTRLA`
+    /// to run `XOSCHF` from an external clock at the range matching `freq`. On
+    /// DA parts the external clock feeds the pin directly, so this does
+    /// nothing. The caller must have just called
+    /// [`CcpUnlock::unlock_ioreg`] (the DB register is protected).
+    fn enable_extclk(&self, freq: HfFreq);
+    /// Selects the external clock as the main clock (`MCLKCTRLA.CLKSEL`). The
+    /// caller must have just called [`CcpUnlock::unlock_ioreg`].
+    fn select_extclk(&self);
+    /// Whether a main-clock source switch is still in progress
+    /// (`MCLKSTATUS.SOSC`). This clears only once the new source is stable, so
+    /// it is the authoritative "switch done" signal.
+    fn switch_in_progress(&self) -> bool;
+}
+
+/// Switches the main clock to an external clock and waits for the switch.
+///
+/// `freq` picks the `XOSCHF.FRQRANGE` on DB parts and is the frequency the
+/// caller should feed to [`Delay`](crate::delay::Delay). It is limited to the
+/// standard OSCHF steps. A non-standard external clock frequency cannot be
+/// represented. DA parts take the clock directly from the pin and ignore
+/// `freq`.
+///
+/// The clock switch is glitchless: the core keeps running on OSCHF until the
+/// external clock is stable, then `MCLKSTATUS.SOSC` clears. The CCP unlocks and
+/// the protected writes happen with interrupts masked. The wait runs after.
+///
+/// # Panics
+/// Panics if the switch does not complete within the defensive spin budget,
+/// which means the external clock is absent or not toggling.
+#[inline]
+pub fn set_extclk<C: CcpUnlock, K: ExtClockControl>(cpu: &C, clkctrl: &K, freq: HfFreq) {
+    avr_device::interrupt::free(|_| {
+        cpu.unlock_ioreg();
+        clkctrl.enable_extclk(freq);
+        cpu.unlock_ioreg();
+        clkctrl.select_extclk();
+    });
+    crate::wait::spin_until(|| !clkctrl.switch_in_progress());
+}
+
+/// External-clock control for DB parts: the clock comes in through `XOSCHF`,
+/// which is configured as an external clock and enabled before the switch.
+macro_rules! impl_extclk_xoschf {
+    ($CLKCTRL:ty) => {
+        impl ExtClockControl for $CLKCTRL {
+            #[inline(always)]
+            fn enable_extclk(&self, freq: HfFreq) {
+                self.xoschfctrla().write(|w| {
+                    w.selhf().extclock();
+                    match freq {
+                        HfFreq::Mhz1
+                        | HfFreq::Mhz2
+                        | HfFreq::Mhz3
+                        | HfFreq::Mhz4
+                        | HfFreq::Mhz8 => w.frqrange()._8m(),
+                        HfFreq::Mhz12 | HfFreq::Mhz16 => w.frqrange()._16m(),
+                        HfFreq::Mhz20 | HfFreq::Mhz24 => w.frqrange()._24m(),
+                    };
+                    w.enable().set_bit()
+                });
+            }
+            #[inline(always)]
+            fn select_extclk(&self) {
+                self.mclkctrla().write(|w| w.clksel().extclk());
+            }
+            fn switch_in_progress(&self) -> bool {
+                self.mclkstatus().read().sosc().bit_is_set()
+            }
+        }
+    };
+}
+
+#[cfg(feature = "avr128db48")]
+impl_extclk_xoschf!(avr_device::avr128db48::CLKCTRL);
+#[cfg(feature = "avr128db64")]
+impl_extclk_xoschf!(avr_device::avr128db64::CLKCTRL);
+#[cfg(feature = "avr128da64")]
+impl ExtClockControl for avr_device::avr128da64::CLKCTRL {
+    fn enable_extclk(&self, _freq: HfFreq) {}
+    fn select_extclk(&self) {
+        self.mclkctrla().write(|w| w.clksel().extclk());
+    }
+    fn switch_in_progress(&self) -> bool {
+        self.mclkstatus().read().sosc().bit_is_set()
+    }
+}
 
 #[cfg(feature = "avr128db48")]
 impl_ccp_unlock!(avr_device::avr128db48::CPU);

--- a/libraries/avrxt-hal/src/rtc.rs
+++ b/libraries/avrxt-hal/src/rtc.rs
@@ -119,3 +119,7 @@ impl_rtc_instance!(avr_device::avr128db48::RTC);
 impl_rtc_instance!(avr_device::avr128db64::RTC);
 #[cfg(feature = "avr128da64")]
 impl_rtc_instance!(avr_device::avr128da64::RTC);
+#[cfg(feature = "attiny406")]
+impl_rtc_instance!(avr_device::attiny406::RTC);
+#[cfg(feature = "attiny416")]
+impl_rtc_instance!(avr_device::attiny416::RTC);

--- a/libraries/avrxt-hal/src/spi.rs
+++ b/libraries/avrxt-hal/src/spi.rs
@@ -8,7 +8,7 @@
 //! [`OutputPin`]: embedded_hal::digital::OutputPin
 
 use embedded_hal::spi::{self, Mode, SpiBus};
-#[cfg(feature = "_avr128")]
+#[cfg(any(feature = "_avr128", feature = "_tinyavr"))]
 use embedded_hal::spi::{Phase, Polarity};
 
 /// SPI clock prescaler (divides `CLK_PER`).
@@ -149,9 +149,50 @@ macro_rules! impl_spis {
     };
 }
 
+// tinyAVR uses the same SPI IP, but its `PRESC` field is an enum
+// (`CLK_PER_4_2`, `CLK_PER_16_8`, ...) rather than the AVR128 `div4()`
+// accessors. With `CLK2X` left at its reset value of 0 the dividers match
+// `Prescaler` one-for-one.
+macro_rules! impl_spi_instance_tiny {
+    ($SPI:ty, $flag:ident) => {
+        impl SpiInstance for $SPI {
+            fn configure(&self, mode: Mode, prescaler: Prescaler) {
+                self.ctrlb().write(|w| {
+                    w.ssd().set_bit();
+                    match (mode.polarity, mode.phase) {
+                        (Polarity::IdleLow, Phase::CaptureOnFirstTransition) => w.mode()._0(),
+                        (Polarity::IdleLow, Phase::CaptureOnSecondTransition) => w.mode()._1(),
+                        (Polarity::IdleHigh, Phase::CaptureOnFirstTransition) => w.mode()._2(),
+                        (Polarity::IdleHigh, Phase::CaptureOnSecondTransition) => w.mode()._3(),
+                    }
+                });
+                self.ctrla().write(|w| {
+                    w.master().set_bit().enable().set_bit();
+                    match prescaler {
+                        Prescaler::Div4 => w.presc().clk_per_4_2(),
+                        Prescaler::Div16 => w.presc().clk_per_16_8(),
+                        Prescaler::Div64 => w.presc().clk_per_64_32(),
+                        Prescaler::Div128 => w.presc().clk_per_128_64(),
+                    }
+                });
+            }
+            fn transfer_byte(&self, byte: u8) -> u8 {
+                self.data().write(|w| w.set(byte));
+                crate::wait::spin_until(|| self.intflags().read().$flag().bit_is_set());
+                self.data().read().bits()
+            }
+        }
+    };
+}
+
 #[cfg(feature = "avr128db48")]
 impl_spis!(avr_device::avr128db48::SPI0, avr_device::avr128db48::SPI1);
 #[cfg(feature = "avr128db64")]
 impl_spis!(avr_device::avr128db64::SPI0, avr_device::avr128db64::SPI1);
 #[cfg(feature = "avr128da64")]
 impl_spis!(avr_device::avr128da64::SPI0, avr_device::avr128da64::SPI1);
+// tinyAVR has a single SPI0 with the enum-typed `PRESC` field.
+#[cfg(feature = "attiny406")]
+impl_spi_instance_tiny!(avr_device::attiny406::SPI0, if_);
+#[cfg(feature = "attiny416")]
+impl_spi_instance_tiny!(avr_device::attiny416::SPI0, default_if);

--- a/libraries/avrxt-hal/src/usart.rs
+++ b/libraries/avrxt-hal/src/usart.rs
@@ -193,6 +193,18 @@ impl<T: UsartInstance> Usart<T> {
         Ok(())
     }
 
+    /// Reconfigures the frame format, keeping the baud rate.
+    ///
+    /// Drains the transmit shift register first, then rewrites
+    /// `CTRLC`/`CTRLB`. The receiver should be idle when this is called. An
+    /// in-flight RX frame may be corrupted by the `CTRLC` rewrite. This lets
+    /// one USART switch between, for example, an 8N1 command link and an 8E2
+    /// UPDI one-wire link on the fly.
+    pub fn set_frame(&mut self, frame: Frame) {
+        self.drain_tx();
+        self.instance.configure(self.baud_reg, frame);
+    }
+
     /// Sends a BREAK: holds the line low well beyond one frame, then restores
     /// the baud rate.
     ///


### PR DESCRIPTION
Extracted from `feat/bootloader` for independent review.

- **clock**: external clock (EXTCLK) selection for AVR128 DA/DB
- **spi**: tinyAVR SPI support with prescaler
- **usart**: `Usart::set_frame` for configurable frame format
- **rtc**: tinyAVR RTC instance

No cross-dependency with the NVMCTRL/RSTCTRL changes in the sibling PR.