### PR TITLE
refactor: trim verbose comments and docs in avrxt-hal

### DIFF
--- a/libraries/avrxt-hal/src/clock.rs
+++ b/libraries/avrxt-hal/src/clock.rs
@@ -2,11 +2,9 @@
 //!
 //! Configuration-change-protected registers are opened with [`CcpUnlock`]. The
 //! per-family clock control lives in submodules: AVR128 selects the internal
-//! high-frequency oscillator (`set_oschf`) or an external clock (`set_extclk`),
-//! tinyAVR runs from `OSC20M` and adjusts the main-clock prescaler
-//! (`set_main_clock_prescaler`). All do the CCP unlock plus the protected write
-//! inside `avr_device::interrupt::free`, so an interrupt cannot land in the
-//! unlock window.
+//! high-frequency oscillator (`set_oschf`) or an external clock
+//! (`set_extclk`), tinyAVR runs from `OSC20M` and adjusts the main-clock
+//! prescaler (`set_main_clock_prescaler`).
 
 #[cfg(feature = "_avr128")]
 pub use self::avr128::{ExtClockControl, HfFreq, OscControl, set_extclk, set_oschf};
@@ -31,8 +29,7 @@ pub trait CcpUnlock {
     fn unlock_spm(&self);
 }
 
-// Shared body, invoked from the family submodule that owns each device. Exposed
-// by path (not textual scope) so it can be used after the `mod` declarations.
+// Exposed by path so family submodules can use it.
 macro_rules! impl_ccp_unlock {
     ($CPU:ty) => {
         impl $crate::clock::CcpUnlock for $CPU {

--- a/libraries/avrxt-hal/src/clock/avr128.rs
+++ b/libraries/avrxt-hal/src/clock/avr128.rs
@@ -1,9 +1,8 @@
 //! AVR128 high-frequency clock control.
 //!
 //! The AVR128 DB/DA family boots on the internal OSCHF at 4 MHz. [`set_oschf`]
-//! selects another OSCHF frequency. [`set_extclk`] switches the main clock to
-//! an external clock instead. `OSCHFCTRLA`, `XOSCHFCTRLA` and `MCLKCTRLA` are
-//! all configuration-change protected.
+//! selects another OSCHF frequency. [`set_extclk`] switches to an external
+//! clock.
 
 use super::{CcpUnlock, impl_ccp_unlock};
 
@@ -49,17 +48,11 @@ pub trait OscControl {
     fn oschf_stable(&self) -> bool;
 }
 
-/// Selects the internal high-frequency oscillator frequency and waits for it to
-/// stabilize. The main clock source stays OSCHF (the reset default) with no
-/// prescaler, so `CLK_PER` becomes `freq`.
-///
-/// `OSCHFCTRLA` is written whole (reset then configure). The CCP unlock and the
-/// protected write happen with interrupts masked so the unlock window cannot be
-/// interrupted.
+/// Selects the internal OSCHF frequency and waits for it to stabilize.
 ///
 /// # Panics
 /// Panics if the oscillator does not report stable within the defensive
-/// spin budget, which means the peripheral is broken or misconfigured.
+/// spin budget.
 #[inline]
 pub fn set_oschf<C: CcpUnlock, K: OscControl>(cpu: &C, clkctrl: &K, freq: HfFreq) {
     avr_device::interrupt::free(|_| {
@@ -100,45 +93,31 @@ impl_osc_control!(avr_device::avr128db64::CLKCTRL);
 #[cfg(feature = "avr128da64")]
 impl_osc_control!(avr_device::avr128da64::CLKCTRL);
 
-/// Controls switching the main clock to an external clock source. Implemented
-/// for each device's `CLKCTRL`. Not for external use.
+/// External clock source control. Implemented for each device's `CLKCTRL`. Not
+/// for external use.
 ///
-/// The two families reach an external clock differently. On DA parts the clock
-/// is fed straight into the EXTCLK pin, so there is no source to enable. On DB
-/// parts it comes in through the `XOSCHF` block, which must be configured as an
-/// external clock and enabled first. Both then select it with
-/// `MCLKCTRLA.CLKSEL` and report progress through `MCLKSTATUS`.
+/// DA parts take the clock directly from the EXTCLK pin. DB parts route it
+/// through `XOSCHF`, which must be configured and enabled first.
 pub trait ExtClockControl {
-    /// Enables the external clock source. On DB parts this writes `XOSCHFCTRLA`
-    /// to run `XOSCHF` from an external clock at the range matching `freq`. On
-    /// DA parts the external clock feeds the pin directly, so this does
-    /// nothing. The caller must have just called
-    /// [`CcpUnlock::unlock_ioreg`] (the DB register is protected).
+    /// Configures and enables the external clock source. No-op on DA. Caller
+    /// must have just called [`CcpUnlock::unlock_ioreg`].
     fn enable_extclk(&self, freq: HfFreq);
-    /// Selects the external clock as the main clock (`MCLKCTRLA.CLKSEL`). The
-    /// caller must have just called [`CcpUnlock::unlock_ioreg`].
+    /// Selects the external clock as the main clock. Caller must have just
+    /// called [`CcpUnlock::unlock_ioreg`].
     fn select_extclk(&self);
-    /// Whether a main-clock source switch is still in progress
-    /// (`MCLKSTATUS.SOSC`). This clears only once the new source is stable, so
-    /// it is the authoritative "switch done" signal.
+    /// Whether the clock switch is still in progress.
     fn switch_in_progress(&self) -> bool;
 }
 
-/// Switches the main clock to an external clock and waits for the switch.
+/// Switches the main clock to an external clock and waits for the switch to
+/// complete.
 ///
 /// `freq` picks the `XOSCHF.FRQRANGE` on DB parts and is the frequency the
-/// caller should feed to [`Delay`](crate::delay::Delay). It is limited to the
-/// standard OSCHF steps. A non-standard external clock frequency cannot be
-/// represented. DA parts take the clock directly from the pin and ignore
-/// `freq`.
-///
-/// The clock switch is glitchless: the core keeps running on OSCHF until the
-/// external clock is stable, then `MCLKSTATUS.SOSC` clears. The CCP unlocks and
-/// the protected writes happen with interrupts masked. The wait runs after.
+/// caller should feed to [`Delay`](crate::delay::Delay). Limited to standard
+/// OSCHF steps. Ignored on DA parts.
 ///
 /// # Panics
-/// Panics if the switch does not complete within the defensive spin budget,
-/// which means the external clock is absent or not toggling.
+/// Panics if the switch does not complete within the defensive spin budget.
 #[inline]
 pub fn set_extclk<C: CcpUnlock, K: ExtClockControl>(cpu: &C, clkctrl: &K, freq: HfFreq) {
     avr_device::interrupt::free(|_| {
@@ -150,8 +129,7 @@ pub fn set_extclk<C: CcpUnlock, K: ExtClockControl>(cpu: &C, clkctrl: &K, freq: 
     crate::wait::spin_until(|| !clkctrl.switch_in_progress());
 }
 
-/// External-clock control for DB parts: the clock comes in through `XOSCHF`,
-/// which is configured as an external clock and enabled before the switch.
+// DB parts: external clock routes through XOSCHF.
 macro_rules! impl_extclk_xoschf {
     ($CLKCTRL:ty) => {
         impl ExtClockControl for $CLKCTRL {

--- a/libraries/avrxt-hal/src/spi.rs
+++ b/libraries/avrxt-hal/src/spi.rs
@@ -106,8 +106,6 @@ impl<T: SpiInstance> SpiBus<u8> for Spi<T> {
     }
 }
 
-// Hidden implementation detail. The bodies are identical across the distinct
-// PAC register types. This private macro only emits trait impls, not types.
 macro_rules! impl_spi_instance {
     ($SPI:ty) => {
         impl SpiInstance for $SPI {
@@ -141,18 +139,15 @@ macro_rules! impl_spi_instance {
     };
 }
 
-// One call per device (grouped, so instances never interleave). All three have
-// SPI0 and SPI1.
+// All three AVR128 devices have SPI0 and SPI1.
 macro_rules! impl_spis {
     ($($SPI:ty),+ $(,)?) => {
         $( impl_spi_instance!($SPI); )+
     };
 }
 
-// tinyAVR uses the same SPI IP, but its `PRESC` field is an enum
-// (`CLK_PER_4_2`, `CLK_PER_16_8`, ...) rather than the AVR128 `div4()`
-// accessors. With `CLK2X` left at its reset value of 0 the dividers match
-// `Prescaler` one-for-one.
+// tinyAVR SPI: enum-typed PRESC accessors instead of AVR128's `div4()`.
+// CLK2X left at 0 so dividers match `Prescaler`.
 macro_rules! impl_spi_instance_tiny {
     ($SPI:ty, $flag:ident) => {
         impl SpiInstance for $SPI {
@@ -191,7 +186,7 @@ impl_spis!(avr_device::avr128db48::SPI0, avr_device::avr128db48::SPI1);
 impl_spis!(avr_device::avr128db64::SPI0, avr_device::avr128db64::SPI1);
 #[cfg(feature = "avr128da64")]
 impl_spis!(avr_device::avr128da64::SPI0, avr_device::avr128da64::SPI1);
-// tinyAVR has a single SPI0 with the enum-typed `PRESC` field.
+// tinyAVR has a single SPI0.
 #[cfg(feature = "attiny406")]
 impl_spi_instance_tiny!(avr_device::attiny406::SPI0, if_);
 #[cfg(feature = "attiny416")]

--- a/libraries/avrxt-hal/src/usart.rs
+++ b/libraries/avrxt-hal/src/usart.rs
@@ -185,8 +185,7 @@ impl<T: UsartInstance> Usart<T> {
     /// `f_cpu_hz`.
     pub fn set_baud(&mut self, baud: u32) -> Result<(), BaudUnattainable> {
         let reg = baud_reg_checked(self.f_cpu_hz, baud)?;
-        // Let any in-flight frame drain before changing baud, otherwise the
-        // trailing frame is truncated when the baud register changes.
+        // Drain TX before changing baud, otherwise the trailing frame is truncated.
         self.drain_tx();
         self.baud_reg = reg;
         self.instance.set_baud_reg(reg);
@@ -195,11 +194,8 @@ impl<T: UsartInstance> Usart<T> {
 
     /// Reconfigures the frame format, keeping the baud rate.
     ///
-    /// Drains the transmit shift register first, then rewrites
-    /// `CTRLC`/`CTRLB`. The receiver should be idle when this is called. An
-    /// in-flight RX frame may be corrupted by the `CTRLC` rewrite. This lets
-    /// one USART switch between, for example, an 8N1 command link and an 8E2
-    /// UPDI one-wire link on the fly.
+    /// Drains the transmit shift register first. The receiver should be idle.
+    /// An in-flight RX frame may be corrupted by the `CTRLC` rewrite.
     pub fn set_frame(&mut self, frame: Frame) {
         self.drain_tx();
         self.instance.configure(self.baud_reg, frame);
@@ -212,8 +208,7 @@ impl<T: UsartInstance> Usart<T> {
     /// break byte is echoed on a one-wire link, so drain the receiver
     /// afterwards.
     pub fn send_break(&mut self) {
-        // Let any in-flight frame drain before changing baud, otherwise the
-        // trailing frame is truncated when the baud register changes.
+        // Drain TX before changing baud, otherwise the trailing frame is truncated.
         self.drain_tx();
         self.instance.set_baud_reg(BREAK_BAUD_REG);
         self.write_byte(0x00);
@@ -221,10 +216,10 @@ impl<T: UsartInstance> Usart<T> {
         self.instance.set_baud_reg(self.baud_reg);
     }
 
-    /// Waits for a pending transmission to fully leave the shift register, then
-    /// clears the transmit-complete flag. Does nothing when nothing is pending:
-    /// TXCIF stays 0 until the first frame completes, so waiting on it before
-    /// any transmission would spin until the defensive budget panics.
+    /// Waits for the pending transmission to leave the shift register, then
+    /// clears TXCIF. No-op when nothing is pending: TXCIF stays 0 until the
+    /// first frame completes, so waiting before any TX would spin until the
+    /// budget panics.
     fn drain_tx(&mut self) {
         if self.tx_pending {
             crate::wait::spin_until(|| self.instance.tx_complete());
@@ -233,9 +228,7 @@ impl<T: UsartInstance> Usart<T> {
         }
     }
 
-    /// Blocks until the transmit buffer can accept a byte, then writes it. The
-    /// transmitter is host-driven, so this cannot hang unless the peripheral is
-    /// broken (in which case it panics rather than spinning forever).
+    /// Blocks until the transmit buffer can accept a byte, then writes it.
     #[inline]
     pub fn write_byte(&mut self, byte: u8) {
         crate::wait::spin_until(|| self.instance.tx_ready());
@@ -272,19 +265,14 @@ impl<T: UsartInstance> embedded_io::Write for Usart<T> {
         Ok(buf.len())
     }
     fn flush(&mut self) -> Result<(), Self::Error> {
-        // Drains only when a frame is pending, and clears the sticky TXCIF
-        // afterwards so the next flush does not return on a stale flag.
         self.drain_tx();
         Ok(())
     }
 }
 
 impl<T: UsartInstance> embedded_io::Read for Usart<T> {
-    // The contract wants `read` to block until at least one byte is available,
-    // then return only what is ready. A UART never reaches EOF, so instead of
-    // returning 0 we block on the first byte (up to the receive timeout) and
-    // then drain whatever else is ready. Filling the whole buffer would deadlock
-    // a caller waiting on a short final frame.
+    // A UART never reaches EOF, so we never return 0. Block on the first byte,
+    // then drain whatever else is ready.
     #[expect(
         clippy::indexing_slicing,
         reason = "indices are bounded by explicit length checks"
@@ -314,13 +302,9 @@ impl<T: UsartInstance> ufmt::uWrite for Usart<T> {
     }
 }
 
-// Hidden implementation detail. The bodies are identical across the distinct
-// PAC register types. This private macro only emits trait impls, not types.
-// The `CTRLC` field accessors differ by ATDF vintage: the AVR128 parts and the
-// attiny406 flatten them (`chsize`/`pmode`/`sbmode`), while the older attiny416
-// models `CTRLC` with register modes (`normal_chsize`/`normal_pmode`/
-// `normal_sbmode`). The value setters (`_8bit`, `even`, `_2bit`, ...) are the
-// same everywhere.
+// `CTRLC` field accessors differ by ATDF vintage: AVR128 and attiny406 flatten
+// them (`chsize`/`pmode`/`sbmode`), while attiny416 uses register modes
+// (`normal_chsize`/`normal_pmode`/`normal_sbmode`).
 macro_rules! impl_usart_instance {
     ($USART:ty, $chsize:ident, $pmode:ident, $sbmode:ident) => {
         impl UsartInstance for $USART {
@@ -350,8 +334,7 @@ macro_rules! impl_usart_instance {
                 self.status().read().txcif().bit_is_set()
             }
             fn clear_tx_complete(&self) {
-                // TXCIF is write-1-to-clear. Writing 0 to the other flags leaves
-                // them untouched, so this does not drop a received byte.
+                // TXCIF is write-1-to-clear. Other flags are untouched.
                 self.status().write(|w| w.txcif().set_bit());
             }
             fn push(&self, byte: u8) {
@@ -367,8 +350,7 @@ macro_rules! impl_usart_instance {
     };
 }
 
-// One call per device (grouped, so instances never interleave and are hard to
-// drop). db48 has USART0..4. db64/da64 add USART5.
+// db48 has USART0..4. db64/da64 add USART5.
 macro_rules! impl_usarts {
     ($chsize:ident, $pmode:ident, $sbmode:ident; $($USART:ty),+ $(,)?) => {
         $( impl_usart_instance!($USART, $chsize, $pmode, $sbmode); )+
@@ -404,8 +386,7 @@ impl_usarts!(
     avr_device::avr128da64::USART4,
     avr_device::avr128da64::USART5,
 );
-// tinyAVR has a single USART0. The attiny406 ATDF flattens `CTRLC`. The older
-// attiny416 ATDF models it with register modes.
+// tinyAVR has a single USART0.
 #[cfg(feature = "attiny406")]
 impl_usarts!(chsize, pmode, sbmode; avr_device::attiny406::USART0);
 #[cfg(feature = "attiny416")]


### PR DESCRIPTION
Doc cleanup that was supposed to be in #40 but didn't make the merge.

- Remove redundant explanations of implementation details visible in the code (interrupt masking, "written whole", glitchless switching)
- Cut verbose macro preambles ("Hidden implementation detail...")
- Shorten trait/method docs to essential information
- Fix two misleading "any in-flight frame" comments to say "TX" (only the transmit side is drained)

No code changes. Clippy clean on all 5 device features.