### PR TITLE
feat: add tinyAVR UPDI programmer and FlashProg trait

### DIFF
--- a/libraries/updi/src/driver.rs
+++ b/libraries/updi/src/driver.rs
@@ -24,11 +24,13 @@ pub const OP_KEY: u8 = 0xE0;
 
 // LDS/STS address-size field (bits 3:2). Data size is one byte (0) throughout.
 pub const ADDR_24: u8 = 2 << 2;
+pub const ADDR_16: u8 = 1 << 2;
 // LD/ST pointer control (bits 3:2).
 pub const PTR_INC: u8 = 1 << 2;
 pub const PTR_SET: u8 = 2 << 2;
-// Pointer-set size field (bits 1:0): a 24-bit address.
+// Pointer-set size field (bits 1:0).
 pub const SIZE_24: u8 = 2;
+pub const SIZE_16: u8 = 1;
 /// Largest block one `REPEAT` can cover (count is a single byte, so 256).
 const REPEAT_MAX: usize = 256;
 
@@ -151,6 +153,46 @@ impl<L: UpdiLink> Updi<L> {
         let [a0, a1, a2, _] = addr.to_le_bytes();
         self.link
             .send(&[SYNCH, OP_ST | PTR_SET | SIZE_24, a0, a1, a2])?;
+        self.expect_ack()
+    }
+
+    /// Loads one byte from a 16-bit data-space address.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UpdiError::Link`] if the transport fails.
+    pub fn lds8_16(&mut self, addr: u16) -> Result<u8, UpdiError<L::Error>> {
+        let [a0, a1] = addr.to_le_bytes();
+        self.link.send(&[SYNCH, OP_LDS | ADDR_16, a0, a1])?;
+        let mut b = [0u8];
+        self.link.recv(&mut b)?;
+        Ok(b[0])
+    }
+
+    /// Stores one byte to a 16-bit data-space address.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UpdiError::NoAck`] if the target does not acknowledge, or
+    /// [`UpdiError::Link`] if the transport fails.
+    pub fn sts8_16(&mut self, addr: u16, val: u8) -> Result<(), UpdiError<L::Error>> {
+        let [a0, a1] = addr.to_le_bytes();
+        self.link.send(&[SYNCH, OP_STS | ADDR_16, a0, a1])?;
+        self.expect_ack()?;
+        self.link.send(&[val])?;
+        self.expect_ack()
+    }
+
+    /// Sets the pointer register to a 16-bit address for `ld_inc`/`st_inc`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UpdiError::NoAck`] if the target does not acknowledge, or
+    /// [`UpdiError::Link`] if the transport fails.
+    pub fn set_pointer_16(&mut self, addr: u16) -> Result<(), UpdiError<L::Error>> {
+        let [a0, a1] = addr.to_le_bytes();
+        self.link
+            .send(&[SYNCH, OP_ST | PTR_SET | SIZE_16, a0, a1])?;
         self.expect_ack()
     }
 

--- a/libraries/updi/src/flash.rs
+++ b/libraries/updi/src/flash.rs
@@ -1,0 +1,107 @@
+//! The common programming interface implemented by every UPDI target family.
+//!
+//! [`Programmer`] (AVR Dx, NVMCTRL v2) and [`TinyProgrammer`] (tinyAVR 0/1,
+//! NVMCTRL v0/v1) expose the same five operations with different command
+//! values and page sizes. [`FlashProg`] factors that shared surface into a
+//! single trait, so a downstream writer (the cellprog `NvmWriter`) can drive
+//! either family through one generic type.
+//!
+//! The trait is sealed: new target families get their own impl inside this
+//! crate.
+
+use crate::link::UpdiLink;
+use crate::programmer::{ProgError, Programmer};
+use crate::tiny::TinyProgrammer;
+
+mod private {
+    pub trait Sealed {}
+    impl<L: super::UpdiLink> Sealed for super::Programmer<L> {}
+    impl<L: super::UpdiLink> Sealed for super::TinyProgrammer<L> {}
+}
+
+/// The common programming interface for a UPDI flash target.
+///
+/// Each call maps one-to-one onto the underlying programmer. The page size is
+/// an associated constant so callers can size their erase bookkeeping at
+/// compile time.
+pub trait FlashProg: private::Sealed {
+    /// Flash page size in bytes.
+    const PAGE_SIZE: u32;
+    /// Error type reported by the programmer.
+    type Error;
+
+    /// Enters programming mode (halts the target).
+    ///
+    /// # Errors
+    ///
+    /// See the implementor.
+    fn enter(&mut self) -> Result<(), Self::Error>;
+    /// Erases the flash page containing `page_base` (a page-aligned address).
+    ///
+    /// # Errors
+    ///
+    /// See the implementor.
+    fn erase_page(&mut self, page_base: u32) -> Result<(), Self::Error>;
+    /// Writes `data` to flash at `addr`. Pages touched must be erased first.
+    ///
+    /// # Errors
+    ///
+    /// See the implementor.
+    fn write(&mut self, addr: u32, data: &[u8]) -> Result<(), Self::Error>;
+    /// Reads `buf.len()` bytes back from flash at `addr`.
+    ///
+    /// # Errors
+    ///
+    /// See the implementor.
+    fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<(), Self::Error>;
+    /// Leaves programming mode and lets the target run.
+    ///
+    /// # Errors
+    ///
+    /// See the implementor.
+    fn leave(&mut self) -> Result<(), Self::Error>;
+}
+
+impl<L: UpdiLink> FlashProg for Programmer<L> {
+    const PAGE_SIZE: u32 = crate::programmer::PAGE_SIZE;
+    type Error = ProgError<L::Error>;
+
+    // Inherent methods shadow the trait methods of the same name, so these
+    // call the underlying `Programmer` implementation rather than recursing.
+    fn enter(&mut self) -> Result<(), Self::Error> {
+        self.enter()
+    }
+    fn erase_page(&mut self, page_base: u32) -> Result<(), Self::Error> {
+        self.erase_flash_page(page_base)
+    }
+    fn write(&mut self, addr: u32, data: &[u8]) -> Result<(), Self::Error> {
+        self.write_flash(addr, data)
+    }
+    fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<(), Self::Error> {
+        self.read_flash(addr, buf)
+    }
+    fn leave(&mut self) -> Result<(), Self::Error> {
+        self.leave()
+    }
+}
+
+impl<L: UpdiLink> FlashProg for TinyProgrammer<L> {
+    const PAGE_SIZE: u32 = crate::tiny::PAGE_SIZE;
+    type Error = ProgError<L::Error>;
+
+    fn enter(&mut self) -> Result<(), Self::Error> {
+        self.enter()
+    }
+    fn erase_page(&mut self, page_base: u32) -> Result<(), Self::Error> {
+        self.erase_flash_page(page_base)
+    }
+    fn write(&mut self, addr: u32, data: &[u8]) -> Result<(), Self::Error> {
+        self.write_flash(addr, data)
+    }
+    fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<(), Self::Error> {
+        self.read_flash(addr, buf)
+    }
+    fn leave(&mut self) -> Result<(), Self::Error> {
+        self.leave()
+    }
+}

--- a/libraries/updi/src/lib.rs
+++ b/libraries/updi/src/lib.rs
@@ -17,6 +17,9 @@
 //!   `driver`.
 //! - [`Programmer`]: the programming layer for AVR Dx (NVMCTRL v2). Unlock,
 //!   reset into programming mode, erase, write, and read back flash.
+//! - [`TinyProgrammer`]: the same for tinyAVR 0/1-series (NVMCTRL v0/v1).
+//! - [`FlashProg`]: the shared surface over both programmers, so a downstream
+//!   writer can be generic in the target family.
 //!
 //! # Features
 //!
@@ -27,11 +30,15 @@
 #![warn(missing_docs)]
 
 pub use self::driver::{Updi, UpdiError};
+pub use self::flash::FlashProg;
 pub use self::link::UpdiLink;
 pub use self::programmer::{PAGE_SIZE, ProgError, Programmer};
+pub use self::tiny::TinyProgrammer;
 
 mod driver;
+mod flash;
 mod link;
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
 mod programmer;
+pub mod tiny;

--- a/libraries/updi/src/mock.rs
+++ b/libraries/updi/src/mock.rs
@@ -6,18 +6,35 @@
 //! the bytes a real slave would. It lets the link and programmer layers run
 //! end to end without hardware. It emulates only the instructions this crate
 //! emits.
+//!
+//! The mock supports two NVM controller models. [`MockTarget::new`] emulates
+//! NVMCTRL v2 (AVR Dx): writing a command to CTRLA *arms* it, and a subsequent
+//! data write *triggers* the armed operation. [`MockTarget::tiny`] emulates
+//! NVMCTRL P0 (tinyAVR 0/1-series): writing a command to CTRLA *executes* it
+//! against the address or page buffer already loaded, so data must come first.
 
 use crate::driver::{
-    ACK, OP_KEY, OP_LD, OP_LDCS, OP_LDS, OP_REPEAT, OP_ST, OP_STCS, OP_STS, PTR_INC, PTR_SET,
-    RESET_RELEASE, RESET_REQUEST, SYNCH, cs,
+    cs, ACK, ADDR_16, ADDR_24, OP_KEY, OP_LD, OP_LDCS, OP_LDS, OP_REPEAT, OP_ST, OP_STCS, OP_STS,
+    PTR_INC, PTR_SET, RESET_RELEASE, RESET_REQUEST, SIZE_16, SIZE_24, SYNCH,
 };
 use crate::link::UpdiLink;
-use crate::programmer::{FLASH_BASE, PAGE_SIZE, asi, nvmctrl};
+use crate::programmer::asi;
 
 /// Mask for the opcode field (the high three bits of an instruction byte).
 const OP_MASK: u8 = 0xE0;
 const FLASH_LEN: usize = 1024;
 const RESP_CAP: usize = 512;
+/// Page-buffer capacity (large enough for the biggest page, AVR Dx 512 B).
+const PAGE_BUF_SIZE: usize = 512;
+
+/// Which NVM controller model the mock emulates.
+#[derive(Clone, Copy, PartialEq)]
+enum NvmModel {
+    /// AVR Dx (NVMCTRL v2): arm-then-trigger.
+    AvrDx,
+    /// tinyAVR 0/1-series (NVMCTRL P0): execute-on-write.
+    TinyAvr,
+}
 
 /// Which store a run of address bytes belongs to.
 #[derive(Clone, Copy)]
@@ -46,10 +63,19 @@ enum Parse {
     },
 }
 
-/// An emulated AVR Dx UPDI target: CS/ASI registers, an NVM controller, and a
-/// small flash array. Enough to run the link and programmer layers end to end.
+/// An emulated UPDI target: CS/ASI registers, an NVM controller, and a small
+/// flash array. Enough to run the link and programmer layers end to end.
 pub struct MockTarget {
+    model: NvmModel,
     flash: [u8; FLASH_LEN],
+    /// Page buffer for the P0 model. Unused on v2.
+    page_buf: [u8; PAGE_BUF_SIZE],
+    /// Flash-array index of the page the page buffer / erase targets. P0 only.
+    target_page: usize,
+    /// Flash base in data space (`0x80_0000` for v2, `0x8000` for P0).
+    flash_base: u32,
+    /// Flash page size in bytes.
+    page_size: usize,
     key_status: u8,
     sys_status: u8,
     locked: bool,
@@ -66,11 +92,16 @@ pub struct MockTarget {
 }
 
 impl MockTarget {
-    /// A fresh, unlocked target with erased flash.
+    /// A fresh, unlocked AVR Dx target with erased flash.
     #[must_use]
     pub const fn new() -> Self {
         Self {
+            model: NvmModel::AvrDx,
             flash: [0xFF; FLASH_LEN],
+            page_buf: [0xFF; PAGE_BUF_SIZE],
+            target_page: 0,
+            flash_base: crate::programmer::FLASH_BASE,
+            page_size: crate::programmer::PAGE_SIZE as usize,
             key_status: 0,
             sys_status: 0,
             locked: false,
@@ -87,7 +118,7 @@ impl MockTarget {
         }
     }
 
-    /// A locked target: only a chip erase clears the lock.
+    /// A locked AVR Dx target: only a chip erase clears the lock.
     #[must_use]
     pub const fn locked() -> Self {
         let mut t = Self::new();
@@ -95,10 +126,38 @@ impl MockTarget {
         t
     }
 
-    /// A target whose NVM controller reports an error on every flash write.
+    /// An AVR Dx target whose NVM controller reports an error on every flash
+    /// write.
     #[must_use]
     pub const fn failing() -> Self {
         let mut t = Self::new();
+        t.fail_nvm = true;
+        t
+    }
+
+    /// A fresh, unlocked tinyAVR target (NVMCTRL P0) with erased flash.
+    #[must_use]
+    pub const fn tiny() -> Self {
+        let mut t = Self::new();
+        t.model = NvmModel::TinyAvr;
+        t.flash_base = crate::tiny::FLASH_BASE as u32;
+        t.page_size = crate::tiny::PAGE_SIZE as usize;
+        t
+    }
+
+    /// A locked tinyAVR target.
+    #[must_use]
+    pub const fn tiny_locked() -> Self {
+        let mut t = Self::tiny();
+        t.locked = true;
+        t
+    }
+
+    /// A tinyAVR target whose NVM controller reports a write error on every
+    /// page commit.
+    #[must_use]
+    pub const fn tiny_failing() -> Self {
+        let mut t = Self::tiny();
         t.fail_nvm = true;
         t
     }
@@ -128,50 +187,68 @@ impl MockTarget {
         n
     }
 
-    const fn flash_index(addr: u32) -> Option<usize> {
-        match addr.checked_sub(FLASH_BASE) {
-            Some(delta) => {
-                let idx = delta as usize;
-                if idx < FLASH_LEN { Some(idx) } else { None }
+    fn flash_index(&self, addr: u32) -> Option<usize> {
+        addr.checked_sub(self.flash_base).and_then(|delta| {
+            let idx = delta as usize;
+            if idx < FLASH_LEN {
+                Some(idx)
+            } else {
+                None
             }
-            None => None,
+        })
+    }
+
+    fn ctrl_addr(&self) -> u32 {
+        match self.model {
+            NvmModel::AvrDx => crate::programmer::nvmctrl::CTRLA,
+            NvmModel::TinyAvr => u32::from(crate::tiny::nvmctrl::CTRLA),
+        }
+    }
+
+    fn status_addr(&self) -> u32 {
+        match self.model {
+            NvmModel::AvrDx => crate::programmer::nvmctrl::STATUS,
+            NvmModel::TinyAvr => u32::from(crate::tiny::nvmctrl::STATUS),
         }
     }
 
     fn data_read(&self, addr: u32) -> u8 {
-        if addr == nvmctrl::STATUS {
-            // The STATUS register is latched at write time and never busy here.
-            // A failing target keeps reporting the error until the next command
-            // is armed. This does not depend on which command is armed at read
-            // time, so the mock stays honest if the programmer reorders its
-            // disarm.
+        if addr == self.status_addr() {
             return self.nvm_status;
         }
-        Self::flash_index(addr).map_or(0, |i| self.flash.get(i).copied().unwrap_or(0))
+        self.flash_index(addr)
+            .map_or(0, |i| self.flash.get(i).copied().unwrap_or(0))
     }
 
     fn data_write(&mut self, addr: u32, val: u8) {
-        if addr == nvmctrl::CTRLA {
+        match self.model {
+            NvmModel::AvrDx => self.data_write_v2(addr, val),
+            NvmModel::TinyAvr => self.data_write_p0(addr, val),
+        }
+    }
+
+    /// AVR Dx (NVMCTRL v2): writing CTRLA arms a command; a subsequent data
+    /// write to a flash address triggers the armed operation.
+    fn data_write_v2(&mut self, addr: u32, val: u8) {
+        if addr == self.ctrl_addr() {
             self.nvm_cmd = val;
-            // Arming a new command clears a previously latched write error.
             self.nvm_status = 0;
             return;
         }
-        let Some(idx) = Self::flash_index(addr) else {
+        let Some(idx) = self.flash_index(addr) else {
             return;
         };
+        let page_size = self.page_size;
         match self.nvm_cmd {
-            nvmctrl::CMD_FLPER => {
-                let page = (idx / PAGE_SIZE as usize) * PAGE_SIZE as usize;
-                for cell in self.flash.iter_mut().skip(page).take(PAGE_SIZE as usize) {
+            crate::programmer::nvmctrl::CMD_FLPER => {
+                let page = (idx / page_size) * page_size;
+                for cell in self.flash.iter_mut().skip(page).take(page_size) {
                     *cell = 0xFF;
                 }
             }
-            nvmctrl::CMD_FLWR => {
-                // A failing target latches the error but still commits the byte,
-                // matching a controller that flags the fault after the write.
+            crate::programmer::nvmctrl::CMD_FLWR => {
                 if self.fail_nvm {
-                    self.nvm_status = nvmctrl::STATUS_ERROR_MASK;
+                    self.nvm_status = crate::programmer::nvmctrl::STATUS_ERROR_MASK;
                 }
                 if let Some(slot) = self.flash.get_mut(idx) {
                     *slot = val;
@@ -181,9 +258,51 @@ impl MockTarget {
         }
     }
 
+    /// tinyAVR (NVMCTRL P0): writing CTRLA executes the command against the
+    /// page buffer or target page already loaded. Flash data writes load the
+    /// page buffer and set the target page.
+    fn data_write_p0(&mut self, addr: u32, val: u8) {
+        if addr == self.ctrl_addr() {
+            self.nvm_cmd = val;
+            self.nvm_status = 0;
+            let page_size = self.page_size;
+            match val {
+                crate::tiny::nvmctrl::CMD_ER => {
+                    for cell in self.flash.iter_mut().skip(self.target_page).take(page_size) {
+                        *cell = 0xFF;
+                    }
+                }
+                crate::tiny::nvmctrl::CMD_WP => {
+                    if self.fail_nvm {
+                        self.nvm_status = crate::tiny::nvmctrl::STATUS_WRERROR;
+                    }
+                    let dst = self.flash.iter_mut().skip(self.target_page);
+                    for (i, cell) in dst.take(page_size).enumerate() {
+                        *cell = self.page_buf.get(i).copied().unwrap_or(0xFF);
+                    }
+                }
+                crate::tiny::nvmctrl::CMD_PBC => {
+                    for slot in &mut self.page_buf {
+                        *slot = 0xFF;
+                    }
+                }
+                _ => {}
+            }
+            return;
+        }
+        let Some(idx) = self.flash_index(addr) else {
+            return;
+        };
+        let page_size = self.page_size;
+        self.target_page = idx - (idx % page_size);
+        if let Some(slot) = self.page_buf.get_mut(idx % page_size) {
+            *slot = val;
+        }
+    }
+
     const fn cs_read(&self, reg: u8) -> u8 {
         match reg {
-            cs::STATUSA => 0x30, // nonzero: alive, UPDI revision in the high nibble
+            cs::STATUSA => 0x30,
             cs::ASI_KEY_STATUS => self.key_status,
             cs::ASI_SYS_STATUS => {
                 self.sys_status | if self.locked { asi::SYS_LOCKSTATUS } else { 0 }
@@ -194,7 +313,7 @@ impl MockTarget {
 
     const fn cs_write(&mut self, reg: u8, val: u8) {
         if reg != cs::ASI_RESET_REQ {
-            return; // CTRLA guard time and others: ignore
+            return;
         }
         if val == RESET_REQUEST {
             self.reset_pending = true;
@@ -207,18 +326,17 @@ impl MockTarget {
     const fn apply_reset(&mut self) {
         if self.key_status & asi::KEYSTAT_CHIPERASE != 0 {
             self.flash = [0xFF; FLASH_LEN];
+            self.page_buf = [0xFF; PAGE_BUF_SIZE];
             self.locked = false;
             self.key_status = 0;
             self.sys_status = 0;
             self.nvm_status = 0;
         } else if self.key_status & asi::KEYSTAT_NVMPROG != 0 {
-            // Enters programming mode, but a locked device stays locked.
             self.sys_status |= asi::SYS_NVMPROG;
         }
     }
 
     fn process_key(&mut self, sent: [u8; 8]) {
-        // Keys travel least-significant byte first, so reverse to recover them.
         let mut key = sent;
         key.reverse();
         if &key == b"NVMProg " {
@@ -296,6 +414,24 @@ impl MockTarget {
         };
     }
 
+    /// Extracts the address byte count from an LDS/STS opcode (bits 3:2).
+    const fn lds_sts_addr_len(op: u8) -> u8 {
+        match op & 0x0C {
+            ADDR_16 => 2,
+            ADDR_24 => 3,
+            _ => 0,
+        }
+    }
+
+    /// Extracts the address byte count from a pointer-set ST opcode (bits 1:0).
+    const fn ptr_set_addr_len(op: u8) -> u8 {
+        match op & 0x03 {
+            SIZE_16 => 2,
+            SIZE_24 => 3,
+            _ => 0,
+        }
+    }
+
     fn opcode(&mut self, op: u8) -> Parse {
         match op & OP_MASK {
             OP_LDCS => {
@@ -306,19 +442,19 @@ impl MockTarget {
             OP_STCS => Parse::Stcs(op & 0x0F),
             OP_LDS => Parse::Addr {
                 kind: AddrKind::Load,
-                need: 3,
+                need: Self::lds_sts_addr_len(op),
                 got: 0,
                 acc: 0,
             },
             OP_STS => Parse::Addr {
                 kind: AddrKind::Store,
-                need: 3,
+                need: Self::lds_sts_addr_len(op),
                 got: 0,
                 acc: 0,
             },
             OP_ST if op & 0x0C == PTR_SET => Parse::Addr {
                 kind: AddrKind::SetPointer,
-                need: 3,
+                need: Self::ptr_set_addr_len(op),
                 got: 0,
                 acc: 0,
             },
@@ -370,7 +506,6 @@ impl UpdiLink for MockTarget {
     type Error = ();
 
     fn break_(&mut self) -> Result<(), ()> {
-        // A BREAK resets the comms state machine, not the system state.
         self.state = Parse::Synch;
         self.resp_len = 0;
         self.resp_head = 0;
@@ -388,7 +523,7 @@ impl UpdiLink for MockTarget {
     fn recv(&mut self, buf: &mut [u8]) -> Result<(), ()> {
         for b in buf.iter_mut() {
             if self.resp_head >= self.resp_len {
-                return Err(()); // underflow: the stack read more than was produced
+                return Err(());
             }
             *b = self.resp.get(self.resp_head).copied().ok_or(())?;
             self.resp_head += 1;

--- a/libraries/updi/src/mock.rs
+++ b/libraries/updi/src/mock.rs
@@ -1,6 +1,6 @@
 //! A mock UPDI target for host tests.
 //!
-//! [`MockTarget`] implements [`UpdiLink`](crate::UpdiLink) by emulating the
+//! [`MockTarget`] implements [`UpdiLink`] by emulating the
 //! target side of the protocol: it parses the instruction byte stream, keeps
 //! the CS and ASI registers, an NVM controller, and a flash array, and returns
 //! the bytes a real slave would. It lets the link and programmer layers run

--- a/libraries/updi/src/tiny.rs
+++ b/libraries/updi/src/tiny.rs
@@ -6,8 +6,14 @@
 //!
 //! The NVMCTRL command values and status bits come from the `ATtiny406` PAC
 //! (`avr_device::attiny406::nvmctrl`) and the ATtiny406/416 datasheets.
+//!
+//! On NVMCTRL P0 (tinyAVR 0/1-series) writing a command to `CTRLA` **executes**
+//! it immediately against the address or page buffer already loaded. This is
+//! the opposite of AVR Dx (NVMCTRL v2), where `CTRLA` **arms** a command and a
+//! subsequent data write triggers it. The erase and write flows below follow
+//! the execute model: set up the address/data first, then write the command.
 
-use crate::driver::{RESET_RELEASE, RESET_REQUEST, Updi, cs};
+use crate::driver::{cs, Updi, RESET_RELEASE, RESET_REQUEST};
 use crate::link::UpdiLink;
 pub use crate::programmer::ProgError;
 
@@ -30,7 +36,7 @@ pub mod nvmctrl {
     /// Status register.
     pub const STATUS: u16 = super::NVMCTRL_BASE + 0x02;
 
-    /// No command (disarm).
+    /// No command.
     pub const CMD_NONE: u8 = 0x00;
     /// Write page.
     pub const CMD_WP: u8 = 0x01;
@@ -40,8 +46,6 @@ pub mod nvmctrl {
     pub const CMD_ERWP: u8 = 0x03;
     /// Page buffer clear.
     pub const CMD_PBC: u8 = 0x04;
-    /// Chip erase.
-    pub const CMD_CHER: u8 = 0x05;
 
     /// Flash busy (STATUS bit 0).
     pub const STATUS_FBUSY: u8 = 1 << 0;
@@ -103,7 +107,8 @@ impl<L: UpdiLink> TinyProgrammer<L> {
         self.wait_prog_mode()
     }
 
-    /// Erases the whole chip with the chip-erase key.
+    /// Erases the whole chip with the chip-erase key, clearing the lock. Follow
+    /// with [`Self::enter`] to program the erased device.
     ///
     /// # Errors
     ///
@@ -123,6 +128,10 @@ impl<L: UpdiLink> TinyProgrammer<L> {
 
     /// Erases the flash page starting at `flash_offset`.
     ///
+    /// On NVMCTRL P0 the page address must be loaded before the erase command
+    /// executes. A dummy store to any address in the page sets the target, then
+    /// `CMD_ER` erases it.
+    ///
     /// # Errors
     ///
     /// See [`ProgError`].
@@ -130,23 +139,18 @@ impl<L: UpdiLink> TinyProgrammer<L> {
         if !flash_offset.is_multiple_of(PAGE_SIZE) || flash_offset >= FLASH_SIZE {
             return Err(ProgError::InvalidOffset);
         }
-        self.nvm_command(nvmctrl::CMD_ER)?;
-        let r = self.do_erase(flash_offset);
-        let disarm = self.nvm_command(nvmctrl::CMD_NONE);
-        r.and(disarm)
-    }
-
-    fn do_erase(&mut self, flash_offset: u32) -> Result<(), ProgError<L::Error>> {
+        self.wait_flash_ready()?;
         let addr =
             FLASH_BASE + u16::try_from(flash_offset).map_err(|_| ProgError::InvalidOffset)?;
         self.updi.sts8_16(addr, 0xFF)?;
+        self.nvm_command(nvmctrl::CMD_ER)?;
         self.wait_flash_ready()
     }
 
     /// Writes `data` to flash at `flash_offset`.
     ///
-    /// Each page touched must be erased first. The final partial page is padded
-    /// with `0xFF` so the page buffer commits.
+    /// Each page touched must be erased first. Data that spans a page boundary
+    /// is programmed one page at a time.
     ///
     /// # Errors
     ///
@@ -187,28 +191,17 @@ impl<L: UpdiLink> TinyProgrammer<L> {
         Ok(())
     }
 
+    /// Clears the page buffer, loads it with `segment`, then commits with
+    /// `CMD_WP`. On P0 the buffer must be loaded before the write command
+    /// executes.
     fn write_page(&mut self, offset: u32, segment: &[u8]) -> Result<(), ProgError<L::Error>> {
-        self.nvm_command(nvmctrl::CMD_WP)?;
-        let r = self.stream_page(offset, segment);
-        let disarm = self.nvm_command(nvmctrl::CMD_NONE);
-        r.and(disarm)
-    }
-
-    fn stream_page(&mut self, offset: u32, segment: &[u8]) -> Result<(), ProgError<L::Error>> {
+        self.wait_flash_ready()?;
+        self.nvm_command(nvmctrl::CMD_PBC)?;
+        self.wait_flash_ready()?;
         let addr = FLASH_BASE + u16::try_from(offset).map_err(|_| ProgError::InvalidOffset)?;
         self.updi.set_pointer_16(addr)?;
-
-        let page_remain = usize::try_from(PAGE_SIZE - (offset % PAGE_SIZE)).unwrap_or(0);
-        if segment.len() < page_remain {
-            // Partial page: pad with 0xFF so the tinyAVR page buffer commits.
-            let mut padded = [0xFFu8; PAGE_SIZE as usize];
-            let (dst, _) = padded.split_at_mut(segment.len());
-            dst.copy_from_slice(segment);
-            let (data, _) = padded.split_at(page_remain);
-            self.updi.st_inc(data)?;
-        } else {
-            self.updi.st_inc(segment)?;
-        }
+        self.updi.st_inc(segment)?;
+        self.nvm_command(nvmctrl::CMD_WP)?;
         self.wait_flash_ready()
     }
 
@@ -292,5 +285,124 @@ impl<L: UpdiLink> TinyProgrammer<L> {
             }
         }
         Err(ProgError::Busy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProgError, TinyProgrammer, FLASH_SIZE, PAGE_SIZE};
+    use crate::mock::MockTarget;
+
+    fn ramp(n: usize) -> [u8; 600] {
+        let mut a = [0u8; 600];
+        for (i, b) in a.iter_mut().enumerate().take(n) {
+            *b = u8::try_from(i % 251).unwrap();
+        }
+        a
+    }
+
+    #[test]
+    fn enter_write_read_roundtrip() {
+        let mut prog = TinyProgrammer::new(MockTarget::tiny());
+        prog.enter().unwrap();
+
+        let data = ramp(64);
+        prog.erase_flash_page(0).unwrap();
+        prog.write_flash(0, &data[..64]).unwrap();
+
+        let mut back = [0u8; 64];
+        prog.read_flash(0, &mut back).unwrap();
+        assert_eq!(&back[..], &data[..64]);
+    }
+
+    #[test]
+    fn erase_sets_page_to_ff() {
+        let mut prog = TinyProgrammer::new(MockTarget::tiny());
+        prog.enter().unwrap();
+        prog.erase_flash_page(0).unwrap();
+        prog.write_flash(0, &[0x11, 0x22, 0x33, 0x44]).unwrap();
+        prog.erase_flash_page(0).unwrap();
+        let mut back = [0u8; 4];
+        prog.read_flash(0, &mut back).unwrap();
+        assert_eq!(back, [0xFF, 0xFF, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn locked_target_cannot_enter() {
+        let mut prog = TinyProgrammer::new(MockTarget::tiny_locked());
+        assert_eq!(prog.enter(), Err(ProgError::Locked));
+    }
+
+    #[test]
+    fn chip_erase_unlocks_then_enter_succeeds() {
+        let mut prog = TinyProgrammer::new(MockTarget::tiny_locked());
+        prog.chip_erase().unwrap();
+        prog.enter().unwrap();
+        prog.erase_flash_page(0).unwrap();
+        prog.write_flash(0, &[0xAB, 0xCD]).unwrap();
+        let mut back = [0u8; 2];
+        prog.read_flash(0, &mut back).unwrap();
+        assert_eq!(back, [0xAB, 0xCD]);
+    }
+
+    #[test]
+    fn second_page_is_addressed() {
+        let mut prog = TinyProgrammer::new(MockTarget::tiny());
+        prog.enter().unwrap();
+        let off = PAGE_SIZE;
+        prog.erase_flash_page(off).unwrap();
+        prog.write_flash(off, &[0x5A; 4]).unwrap();
+        let mut back = [0u8; 4];
+        prog.read_flash(off, &mut back).unwrap();
+        assert_eq!(back, [0x5A; 4]);
+    }
+
+    #[test]
+    fn write_across_page_boundary_roundtrips() {
+        let mut prog = TinyProgrammer::new(MockTarget::tiny());
+        prog.enter().unwrap();
+        prog.erase_flash_page(0).unwrap();
+        prog.erase_flash_page(PAGE_SIZE).unwrap();
+        let data = ramp(20);
+        let off = PAGE_SIZE - 8;
+        prog.write_flash(off, &data[..20]).unwrap();
+        let mut back = [0u8; 20];
+        prog.read_flash(off, &mut back).unwrap();
+        assert_eq!(&back[..], &data[..20]);
+    }
+
+    #[test]
+    fn odd_length_write_roundtrips() {
+        let mut prog = TinyProgrammer::new(MockTarget::tiny());
+        prog.enter().unwrap();
+        prog.erase_flash_page(0).unwrap();
+        let data = [0x01, 0x02, 0x03];
+        prog.write_flash(0, &data).unwrap();
+        let mut back = [0u8; 3];
+        prog.read_flash(0, &mut back).unwrap();
+        assert_eq!(back, data);
+    }
+
+    #[test]
+    fn misaligned_offsets_are_rejected() {
+        let mut prog = TinyProgrammer::new(MockTarget::tiny());
+        prog.enter().unwrap();
+        assert_eq!(
+            prog.write_flash(1, &[0xAA, 0xBB]),
+            Err(ProgError::InvalidOffset)
+        );
+        assert_eq!(prog.erase_flash_page(1), Err(ProgError::InvalidOffset));
+        assert_eq!(
+            prog.erase_flash_page(FLASH_SIZE),
+            Err(ProgError::InvalidOffset)
+        );
+    }
+
+    #[test]
+    fn write_reports_nvm_error() {
+        let mut prog = TinyProgrammer::new(MockTarget::tiny_failing());
+        prog.enter().unwrap();
+        prog.erase_flash_page(0).unwrap();
+        assert_eq!(prog.write_flash(0, &[0x11, 0x22]), Err(ProgError::NvmError));
     }
 }

--- a/libraries/updi/src/tiny.rs
+++ b/libraries/updi/src/tiny.rs
@@ -1,0 +1,296 @@
+//! The programming layer for tinyAVR 0/1-series targets.
+//!
+//! [`TinyProgrammer`] unlocks the target, resets it into programming mode, and
+//! erases, writes, and reads back flash over the [`Updi`] driver using 16-bit
+//! data-space addresses.
+//!
+//! The NVMCTRL command values and status bits come from the `ATtiny406` PAC
+//! (`avr_device::attiny406::nvmctrl`) and the ATtiny406/416 datasheets.
+
+use crate::driver::{RESET_RELEASE, RESET_REQUEST, Updi, cs};
+use crate::link::UpdiLink;
+pub use crate::programmer::ProgError;
+
+/// NVMCTRL base in the 16-bit data space (shared by tinyAVR 0/1-series).
+const NVMCTRL_BASE: u16 = 0x1000;
+
+/// Base of program flash in the 16-bit data space.
+pub const FLASH_BASE: u16 = 0x8000;
+
+/// Total flash size for ATtiny406/ATtiny416 (4 KB).
+pub const FLASH_SIZE: u32 = 4096;
+
+/// Flash page size in bytes.
+pub const PAGE_SIZE: u32 = 16;
+
+/// NVM controller registers, commands, and status flags.
+pub mod nvmctrl {
+    /// Command register (CTRLA).
+    pub const CTRLA: u16 = super::NVMCTRL_BASE;
+    /// Status register.
+    pub const STATUS: u16 = super::NVMCTRL_BASE + 0x02;
+
+    /// No command (disarm).
+    pub const CMD_NONE: u8 = 0x00;
+    /// Write page.
+    pub const CMD_WP: u8 = 0x01;
+    /// Page erase.
+    pub const CMD_ER: u8 = 0x02;
+    /// Erase and write page.
+    pub const CMD_ERWP: u8 = 0x03;
+    /// Page buffer clear.
+    pub const CMD_PBC: u8 = 0x04;
+    /// Chip erase.
+    pub const CMD_CHER: u8 = 0x05;
+
+    /// Flash busy (STATUS bit 0).
+    pub const STATUS_FBUSY: u8 = 1 << 0;
+    /// Write error (STATUS bit 2).
+    pub const STATUS_WRERROR: u8 = 1 << 2;
+}
+
+/// ASI status-register bits (shared by all UPDI devices).
+pub mod asi {
+    /// Chip-erase key accepted.
+    pub const KEYSTAT_CHIPERASE: u8 = 1 << 3;
+    /// NVMPROG key accepted.
+    pub const KEYSTAT_NVMPROG: u8 = 1 << 4;
+    /// Target locked.
+    pub const SYS_LOCKSTATUS: u8 = 1 << 0;
+    /// Programming mode active.
+    pub const SYS_NVMPROG: u8 = 1 << 3;
+}
+
+const KEY_NVMPROG: &[u8; 8] = b"NVMProg ";
+const KEY_CHIPERASE: &[u8; 8] = b"NVMErase";
+const GUARD_TIME: u8 = 0x00;
+const MAX_POLL: u32 = 100_000;
+
+/// A UPDI programmer for a tinyAVR 0/1-series target.
+pub struct TinyProgrammer<L> {
+    updi: Updi<L>,
+}
+
+impl<L: UpdiLink> TinyProgrammer<L> {
+    /// Wraps a transport.
+    pub const fn new(link: L) -> Self {
+        Self {
+            updi: Updi::new(link),
+        }
+    }
+
+    /// Releases the transport.
+    pub fn free(self) -> L {
+        self.updi.free()
+    }
+
+    /// Enters programming mode.
+    ///
+    /// # Errors
+    ///
+    /// See [`ProgError`].
+    pub fn enter(&mut self) -> Result<(), ProgError<L::Error>> {
+        self.updi.break_()?;
+        if self.updi.ldcs(cs::STATUSA)? == 0 {
+            return Err(ProgError::NotAlive);
+        }
+        self.updi.stcs(cs::CTRLA, GUARD_TIME)?;
+        self.updi.key(KEY_NVMPROG)?;
+        if self.updi.ldcs(cs::ASI_KEY_STATUS)? & asi::KEYSTAT_NVMPROG == 0 {
+            return Err(ProgError::KeyRejected);
+        }
+        self.reset()?;
+        self.wait_prog_mode()
+    }
+
+    /// Erases the whole chip with the chip-erase key.
+    ///
+    /// # Errors
+    ///
+    /// See [`ProgError`].
+    pub fn chip_erase(&mut self) -> Result<(), ProgError<L::Error>> {
+        self.updi.break_()?;
+        if self.updi.ldcs(cs::STATUSA)? == 0 {
+            return Err(ProgError::NotAlive);
+        }
+        self.updi.key(KEY_CHIPERASE)?;
+        if self.updi.ldcs(cs::ASI_KEY_STATUS)? & asi::KEYSTAT_CHIPERASE == 0 {
+            return Err(ProgError::KeyRejected);
+        }
+        self.reset()?;
+        self.wait_erase_done()
+    }
+
+    /// Erases the flash page starting at `flash_offset`.
+    ///
+    /// # Errors
+    ///
+    /// See [`ProgError`].
+    pub fn erase_flash_page(&mut self, flash_offset: u32) -> Result<(), ProgError<L::Error>> {
+        if !flash_offset.is_multiple_of(PAGE_SIZE) || flash_offset >= FLASH_SIZE {
+            return Err(ProgError::InvalidOffset);
+        }
+        self.nvm_command(nvmctrl::CMD_ER)?;
+        let r = self.do_erase(flash_offset);
+        let disarm = self.nvm_command(nvmctrl::CMD_NONE);
+        r.and(disarm)
+    }
+
+    fn do_erase(&mut self, flash_offset: u32) -> Result<(), ProgError<L::Error>> {
+        let addr =
+            FLASH_BASE + u16::try_from(flash_offset).map_err(|_| ProgError::InvalidOffset)?;
+        self.updi.sts8_16(addr, 0xFF)?;
+        self.wait_flash_ready()
+    }
+
+    /// Writes `data` to flash at `flash_offset`.
+    ///
+    /// Each page touched must be erased first. The final partial page is padded
+    /// with `0xFF` so the page buffer commits.
+    ///
+    /// # Errors
+    ///
+    /// See [`ProgError`].
+    pub fn write_flash(
+        &mut self,
+        flash_offset: u32,
+        data: &[u8],
+    ) -> Result<(), ProgError<L::Error>> {
+        if data.is_empty() {
+            return Ok(());
+        }
+        if !flash_offset.is_multiple_of(2) {
+            return Err(ProgError::InvalidOffset);
+        }
+        let len = u32::try_from(data.len()).map_err(|_| ProgError::InvalidOffset)?;
+        let end = flash_offset
+            .checked_add(len)
+            .ok_or(ProgError::InvalidOffset)?;
+        if end > FLASH_SIZE {
+            return Err(ProgError::InvalidOffset);
+        }
+
+        let mut offset = flash_offset;
+        let mut rest = data;
+        while !rest.is_empty() {
+            let page_end = (offset / PAGE_SIZE + 1) * PAGE_SIZE;
+            let to_boundary = usize::try_from(page_end - offset).unwrap_or(rest.len());
+            if rest.len() <= to_boundary {
+                self.write_page(offset, rest)?;
+                break;
+            }
+            let (segment, tail) = rest.split_at(to_boundary);
+            self.write_page(offset, segment)?;
+            offset = page_end;
+            rest = tail;
+        }
+        Ok(())
+    }
+
+    fn write_page(&mut self, offset: u32, segment: &[u8]) -> Result<(), ProgError<L::Error>> {
+        self.nvm_command(nvmctrl::CMD_WP)?;
+        let r = self.stream_page(offset, segment);
+        let disarm = self.nvm_command(nvmctrl::CMD_NONE);
+        r.and(disarm)
+    }
+
+    fn stream_page(&mut self, offset: u32, segment: &[u8]) -> Result<(), ProgError<L::Error>> {
+        let addr = FLASH_BASE + u16::try_from(offset).map_err(|_| ProgError::InvalidOffset)?;
+        self.updi.set_pointer_16(addr)?;
+
+        let page_remain = usize::try_from(PAGE_SIZE - (offset % PAGE_SIZE)).unwrap_or(0);
+        if segment.len() < page_remain {
+            // Partial page: pad with 0xFF so the tinyAVR page buffer commits.
+            let mut padded = [0xFFu8; PAGE_SIZE as usize];
+            let (dst, _) = padded.split_at_mut(segment.len());
+            dst.copy_from_slice(segment);
+            let (data, _) = padded.split_at(page_remain);
+            self.updi.st_inc(data)?;
+        } else {
+            self.updi.st_inc(segment)?;
+        }
+        self.wait_flash_ready()
+    }
+
+    /// Reads `buf.len()` bytes from flash at `flash_offset`.
+    ///
+    /// # Errors
+    ///
+    /// See [`ProgError`].
+    pub fn read_flash(
+        &mut self,
+        flash_offset: u32,
+        buf: &mut [u8],
+    ) -> Result<(), ProgError<L::Error>> {
+        if buf.is_empty() {
+            return Ok(());
+        }
+        let len = u32::try_from(buf.len()).map_err(|_| ProgError::InvalidOffset)?;
+        let end = flash_offset
+            .checked_add(len)
+            .ok_or(ProgError::InvalidOffset)?;
+        if end > FLASH_SIZE {
+            return Err(ProgError::InvalidOffset);
+        }
+        let addr =
+            FLASH_BASE + u16::try_from(flash_offset).map_err(|_| ProgError::InvalidOffset)?;
+        self.updi.set_pointer_16(addr)?;
+        self.updi.ld_inc(buf)?;
+        Ok(())
+    }
+
+    /// Leaves programming mode and lets the target run.
+    ///
+    /// # Errors
+    ///
+    /// See [`ProgError`].
+    pub fn leave(&mut self) -> Result<(), ProgError<L::Error>> {
+        self.reset()
+    }
+
+    fn reset(&mut self) -> Result<(), ProgError<L::Error>> {
+        self.updi.stcs(cs::ASI_RESET_REQ, RESET_REQUEST)?;
+        self.updi.stcs(cs::ASI_RESET_REQ, RESET_RELEASE)?;
+        Ok(())
+    }
+
+    fn wait_prog_mode(&mut self) -> Result<(), ProgError<L::Error>> {
+        for _ in 0..MAX_POLL {
+            let status = self.updi.ldcs(cs::ASI_SYS_STATUS)?;
+            if status & asi::SYS_LOCKSTATUS != 0 {
+                return Err(ProgError::Locked);
+            }
+            if status & asi::SYS_NVMPROG != 0 {
+                return Ok(());
+            }
+        }
+        Err(ProgError::EnterTimeout)
+    }
+
+    fn wait_erase_done(&mut self) -> Result<(), ProgError<L::Error>> {
+        for _ in 0..MAX_POLL {
+            if self.updi.ldcs(cs::ASI_SYS_STATUS)? & asi::SYS_LOCKSTATUS == 0 {
+                return self.wait_flash_ready();
+            }
+        }
+        Err(ProgError::EraseTimeout)
+    }
+
+    fn nvm_command(&mut self, cmd: u8) -> Result<(), ProgError<L::Error>> {
+        self.updi.sts8_16(nvmctrl::CTRLA, cmd)?;
+        Ok(())
+    }
+
+    fn wait_flash_ready(&mut self) -> Result<(), ProgError<L::Error>> {
+        for _ in 0..MAX_POLL {
+            let status = self.updi.lds8_16(nvmctrl::STATUS)?;
+            if status & nvmctrl::STATUS_WRERROR != 0 {
+                return Err(ProgError::NvmError);
+            }
+            if status & nvmctrl::STATUS_FBUSY == 0 {
+                return Ok(());
+            }
+        }
+        Err(ProgError::Busy)
+    }
+}


### PR DESCRIPTION
Extracts the tinyAVR UPDI support from `feat/bootloader`:

- `TinyProgrammer` (`tiny.rs`): unlock, erase, write, and read flash on tinyAVR 0/1-series targets over 16-bit data-space addresses
- `FlashProg` (`flash.rs`): sealed trait that unifies `Programmer` (AVR Dx) and `TinyProgrammer` (tinyAVR) behind one interface, so a downstream writer can be generic over the target family
- `driver.rs`: `lds8_16`, `sts8_16`, `set_pointer_16` for 16-bit data-space addressing